### PR TITLE
Support to encapsulated web elements added

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ v1.5.4.dev0
 
 *Release date: WIP*
 
+- Add support to encapsulated elements (Shadowroot)
+
+    | Only support CSS_SELECTOR locator
+    | It is not supported for list of elements yet
+    | It is not supported for element find by parent yet
+    | It is not supported nested encapsulation yet
+
 v1.5.3
 ------
 

--- a/toolium/pageelements/group_page_element.py
+++ b/toolium/pageelements/group_page_element.py
@@ -24,7 +24,7 @@ from toolium.pageobjects.page_object import PageObject
 
 
 class Group(PageObject, PageElement):
-    def __init__(self, by, value, parent=None, driver_wrapper=None, order=None, wait=False):
+    def __init__(self, by, value, parent=None, driver_wrapper=None, order=None, wait=False, shadowroot= None):
         """Initialize the Group object with the given locator components.
 
         If parent is not None, find_elements will be performed over it, instead of
@@ -36,12 +36,14 @@ class Group(PageObject, PageElement):
         :param driver_wrapper: driver wrapper instance
         :param order: index value if the locator returns more than one element
         :param wait: True if the page element must be loaded in wait_until_loaded method of the container page object
+        :param shadowroot: CSS SELECTOR of JS element where shadowroot tag appears
         """
         self.logger = logging.getLogger(__name__)  #: logger instance
         self.locator = (by, value)  #: tuple with locator type and locator value
         self.parent = parent  #: element from which to find actual elements
         self.order = order  #: index value if the locator returns more than one element
         self.wait = wait  #: True if it must be loaded in wait_until_loaded method of the container page object
+        self.shadowroot = shadowroot  #: CSS SELECTOR of the shadowroot for encapsulated element
         self.driver_wrapper = driver_wrapper if driver_wrapper else \
             DriverWrappersPool.get_default_wrapper()  #: driver wrapper instance
         self.init_page_elements()

--- a/toolium/pageelements/group_page_element.py
+++ b/toolium/pageelements/group_page_element.py
@@ -24,7 +24,7 @@ from toolium.pageobjects.page_object import PageObject
 
 
 class Group(PageObject, PageElement):
-    def __init__(self, by, value, parent=None, driver_wrapper=None, order=None, wait=False, shadowroot= None):
+    def __init__(self, by, value, parent=None, driver_wrapper=None, order=None, wait=False):
         """Initialize the Group object with the given locator components.
 
         If parent is not None, find_elements will be performed over it, instead of
@@ -43,7 +43,7 @@ class Group(PageObject, PageElement):
         self.parent = parent  #: element from which to find actual elements
         self.order = order  #: index value if the locator returns more than one element
         self.wait = wait  #: True if it must be loaded in wait_until_loaded method of the container page object
-        self.shadowroot = shadowroot  #: CSS SELECTOR of the shadowroot for encapsulated element
+        self.shadowroot = None  #: Not implemented for PAgeElements yet
         self.driver_wrapper = driver_wrapper if driver_wrapper else \
             DriverWrappersPool.get_default_wrapper()  #: driver wrapper instance
         self.init_page_elements()

--- a/toolium/pageelements/page_element.py
+++ b/toolium/pageelements/page_element.py
@@ -32,7 +32,7 @@ class PageElement(CommonObject):
                   or (selenium.webdriver.common.by.By or appium.webdriver.common.mobileby.MobileBy, str)
     """
 
-    def __init__(self, by, value, parent=None, order=None, wait=False):
+    def __init__(self, by, value, parent=None, order=None, wait=False, shadowroot= None):
         """Initialize the PageElement object with the given locator components.
 
         If parent is not None, find_element will be performed over it, instead of
@@ -43,12 +43,14 @@ class PageElement(CommonObject):
         :param parent: parent element (WebElement, PageElement or locator tuple)
         :param order: index value if the locator returns more than one element
         :param wait: True if the page element must be loaded in wait_until_loaded method of the container page object
+        :param shadowroot: CSS SELECTOR of JS element where shadowroot tag appears
         """
         super(PageElement, self).__init__()
         self.locator = (by, value)  #: tuple with locator type and locator value
         self.parent = parent  #: element from which to find actual elements
         self.order = order  #: index value if the locator returns more than one element
         self.wait = wait  #: True if it must be loaded in wait_until_loaded method of the container page object
+        self.shadowroot = shadowroot  #: CSS SELECTOR of the shadowroot for encapsulated element
         self.driver_wrapper = DriverWrappersPool.get_default_wrapper()  #: driver wrapper instance
         self.reset_object(self.driver_wrapper)
 
@@ -81,11 +83,19 @@ class PageElement(CommonObject):
     def _find_web_element(self):
         """Find WebElement using element locator and save it in _web_element attribute"""
         if not self._web_element or not self.config.getboolean_optional('Driver', 'save_web_element'):
-            # Element will be finded from parent element or from driver
-            base = self.utils.get_web_element(self.parent) if self.parent else self.driver
-            # Find elements and get the correct index or find a single element
-            self._web_element = base.find_elements(*self.locator)[self.order] if self.order else base.find_element(
-                *self.locator)
+            # If the element is encapsulated we use the shadowroot tag in yaml (eg. Shadowroot: root_element_name)
+            if self.shadowroot:
+                # querySelector only support CSS SELECTOR locator
+                self._web_element = self.driver.execute_script('return document.querySelector("%s")'
+                                                           '.shadowRoot.querySelector("%s")' % (self.shadowroot, self.locator[1]))
+            else:
+                # Element will be finded from parent element or from driver
+                base = self.utils.get_web_element(self.parent) if self.parent else self.driver
+                # Find elements and get the correct index or find a single element
+                self._web_element = base.find_elements(*self.locator)[self.order] if self.order else base.find_element(
+                    *self.locator)
+                #self._web_element = base.find_elements(*self.locator)[self.order] if self.order else base.find_element(
+                #    *self.locator)
 
     def scroll_element_into_view(self):
         """Scroll element into view

--- a/toolium/pageelements/page_element.py
+++ b/toolium/pageelements/page_element.py
@@ -17,6 +17,7 @@ limitations under the License.
 """
 
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.by import By
 
 from toolium.driver_wrapper import DriverWrappersPool
 from toolium.pageobjects.common_object import CommonObject
@@ -32,7 +33,7 @@ class PageElement(CommonObject):
                   or (selenium.webdriver.common.by.By or appium.webdriver.common.mobileby.MobileBy, str)
     """
 
-    def __init__(self, by, value, parent=None, order=None, wait=False, shadowroot= None):
+    def __init__(self, by, value, parent=None, order=None, wait=False, shadowroot=None):
         """Initialize the PageElement object with the given locator components.
 
         If parent is not None, find_element will be performed over it, instead of
@@ -85,6 +86,8 @@ class PageElement(CommonObject):
         if not self._web_element or not self.config.getboolean_optional('Driver', 'save_web_element'):
             # If the element is encapsulated we use the shadowroot tag in yaml (eg. Shadowroot: root_element_name)
             if self.shadowroot:
+                if self.locator[0] != By.CSS_SELECTOR:
+                    raise Exception('Locator type should be CSS_SELECTOR but found: '.format(self.locator[0]))
                 # querySelector only support CSS SELECTOR locator
                 self._web_element = self.driver.execute_script('return document.querySelector("%s")'
                                                            '.shadowRoot.querySelector("%s")' % (self.shadowroot, self.locator[1]))
@@ -94,8 +97,6 @@ class PageElement(CommonObject):
                 # Find elements and get the correct index or find a single element
                 self._web_element = base.find_elements(*self.locator)[self.order] if self.order else base.find_element(
                     *self.locator)
-                #self._web_element = base.find_elements(*self.locator)[self.order] if self.order else base.find_element(
-                #    *self.locator)
 
     def scroll_element_into_view(self):
         """Scroll element into view

--- a/toolium/pageelements/page_elements.py
+++ b/toolium/pageelements/page_elements.py
@@ -40,7 +40,7 @@ class PageElements(CommonObject):
     """
     page_element_class = PageElement  #: class of page elements (PageElement, Button...)
 
-    def __init__(self, by, value, parent=None, page_element_class=None, order=None):
+    def __init__(self, by, value, parent=None, page_element_class=None, order=None, shadowroot= None):
         """Initialize the PageElements object with the given locator components.
 
         If parent is not None, find_elements will be performed over it, instead of
@@ -51,11 +51,13 @@ class PageElements(CommonObject):
         :param parent: parent element (WebElement, PageElement or locator tuple)
         :param order: index value if the locator returns more than one element
         :param page_element_class: class of page elements (PageElement, Button...)
+        :param shadowroot: CSS SELECTOR of JS element where shadowroot tag appears
         """
         super(PageElements, self).__init__()
         self.locator = (by, value)  #: tuple with locator type and locator value
         self.parent = parent  #: element from which to find actual elements
         self.order = order  #: index value if the locator returns more than one element
+        self.shadowroot = shadowroot  #: CSS SELECTOR of the shadowroot for encapsulated element
         self.driver_wrapper = DriverWrappersPool.get_default_wrapper()  #: driver wrapper instance
         # update instance element class or use PageElement class
         if page_element_class:

--- a/toolium/pageelements/page_elements.py
+++ b/toolium/pageelements/page_elements.py
@@ -40,7 +40,7 @@ class PageElements(CommonObject):
     """
     page_element_class = PageElement  #: class of page elements (PageElement, Button...)
 
-    def __init__(self, by, value, parent=None, page_element_class=None, order=None, shadowroot= None):
+    def __init__(self, by, value, parent=None, page_element_class=None, order=None):
         """Initialize the PageElements object with the given locator components.
 
         If parent is not None, find_elements will be performed over it, instead of
@@ -57,7 +57,7 @@ class PageElements(CommonObject):
         self.locator = (by, value)  #: tuple with locator type and locator value
         self.parent = parent  #: element from which to find actual elements
         self.order = order  #: index value if the locator returns more than one element
-        self.shadowroot = shadowroot  #: CSS SELECTOR of the shadowroot for encapsulated element
+        self.shadowroot = None  #: Not implemented for PAgeElements yet
         self.driver_wrapper = DriverWrappersPool.get_default_wrapper()  #: driver wrapper instance
         # update instance element class or use PageElement class
         if page_element_class:


### PR DESCRIPTION
- Add support to encapsulated elements (Shadowroot)

    | Only support CSS_SELECTOR locator
    | It is not supported for list of elements yet
    | It is not supported for element find by parent yet
    | It is not supported nested encapsulation yet