### PR TITLE
fix: improve dyn envs outputs

### DIFF
--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -292,5 +292,5 @@ class DynamicEnvironment:
             raise
 
         scenario.steps[0].status = status
-        scenario.steps[0].exception = Exception("Preconditions failed")
+        scenario.steps[0].exception = self.error_exception
         scenario.steps[0].error_message = self.error_exception.message

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -292,5 +292,5 @@ class DynamicEnvironment:
             raise
 
         scenario.steps[0].status = status
-        scenario.steps[0].exception = self.error_exception
+        scenario.steps[0].exception = Exception("Preconditions failed")
         scenario.steps[0].error_message = self.error_exception.message

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -210,6 +210,7 @@ class DynamicEnvironment:
                     elif action in [ACTIONS_BEFORE_SCENARIO]:
                         self.scenario_error = True
                     self.logger.error(exc)
+                    self.error_exception = exc
                     break
 
     def reset_error_status(self):
@@ -292,4 +293,4 @@ class DynamicEnvironment:
 
         scenario.steps[0].status = status
         scenario.steps[0].exception = Exception("Preconditions failed")
-        scenario.steps[0].error_message = "Failing steps due to precondition exceptions"
+        scenario.steps[0].error_message = self.error_exception.message


### PR DESCRIPTION
Right now when a dynamic environment fails, the error description is "Failing steps due to precondition exceptions":

```
<error message="Preconditions failed" type="Exception">
<![CDATA[
Failing step: Given get the pi-scope "qa_piscope_roles_2" as "baikal-api", and save it in aws using filename "qa_piscope_roles_2_base" ... failed in 0.000s Location: features/upgrade/base_version.feature:100 Failing steps due to precondition exceptions
]]>
</error>
```

with this fix, the description should add the exception that has failed