### PR TITLE
fix: dyn environment for exit codes when hook error is detected

### DIFF
--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -273,6 +273,7 @@ class DynamicEnvironment:
             context.feature.reset()
             for scenario in context.feature.walk_scenarios():
                 context.dyn_env.fail_first_step_precondition_exception(scenario)
+            raise Exception("Preconditions failed during the execution")
 
     def fail_first_step_precondition_exception(self, scenario):
         """


### PR DESCRIPTION
# Description
Current implementation for dynamic environment failures using `Behave 1.2.6` is not properly managing exit codes in the execution:

```
$ behave
... Steps failed in dyn-env steps ...
...
0 features passed, 1 failed, 0 skipped
0 scenarios passed, 2 failed, 0 skipped
0 steps passed, 2 failed, 0 skipped, 0 undefined, 17 untested
Took 0m0.000s
/app # echo $?
0
```

# Changes
After this fix, when some step fail in dyn-env (before/after scenario/feature), a hook error will be managed at the end of the execution (after_feature):

```
$behave 

... Steps failed in dyn-env steps ...
...

HOOK-ERROR in after_feature: Exception: Preconditions failed

Failing scenarios:
  ...

0 features passed, 1 failed, 0 skipped
0 scenarios passed, 2 failed, 0 skipped
0 steps passed, 2 failed, 0 skipped, 0 undefined, 17 untested
Took 0m0.000s
/app # echo $?
1
```

This way, behave is now managing hooks error for giving a valid status code when some error detected is detected in dyn-env.