### PR TITLE
Support for different binary location for Chrome browser

### DIFF
--- a/docs/browser_configuration.rst
+++ b/docs/browser_configuration.rst
@@ -218,6 +218,15 @@ For example, to use a predefined chrome profile::
     [ChromeArguments]
     user-data-dir: C:\Users\USERNAME\AppData\Local\Google\Chrome\User Data
 
+When Chrome is installed in a non-default location, configure the Chrome binary path in *[Chrome]* configuration
+section::
+
+    [Driver]
+    type: chrome
+
+    [Chrome]
+    binary: /usr/local/chrome_beta/chrome
+
 Another examples showing how to use
 `Chrome Device Mode <https://sites.google.com/a/chromium.org/chromedriver/mobile-emulation>`_ in two different ways::
 

--- a/toolium/config_driver.py
+++ b/toolium/config_driver.py
@@ -315,6 +315,9 @@ class ConfigDriver(object):
 
         :returns: chrome options object
         """
+        # Get Chrome binary
+        chrome_binary = self.config.get_optional('Chrome', 'binary')
+
         # Create Chrome options
         options = webdriver.ChromeOptions()
 
@@ -323,6 +326,9 @@ class ConfigDriver(object):
             options.add_argument('--headless')
             if os.name == 'nt':  # Temporarily needed if running on Windows.
                 options.add_argument('--disable-gpu')
+
+        if chrome_binary is not None:
+            options.binary_location = chrome_binary
 
         # Add Chrome preferences, mobile emulation options and chrome arguments
         self._add_chrome_options(options, 'prefs')


### PR DESCRIPTION
Allow for different binary location for Chrome browser. 
Section: Chrome.
Option: binary.

Example in properties.cfg:

```
[Driver]
type: chrome

[Chrome]
binary: /usr/local/chrome_beta/chrome
```
