### PR TITLE
feat(ssl-remote-server): https for remote servers available using -D Server_ssl=true

### DIFF
--- a/toolium/utils.py
+++ b/toolium/utils.py
@@ -464,10 +464,11 @@ class Utils(object):
         """
         server_host = self.driver_wrapper.config.get('Server', 'host')
         server_port = self.driver_wrapper.config.get('Server', 'port')
+        server_ssl = 'https' if self.driver_wrapper.config.getboolean_optional('Server', 'ssl') else 'http'
         server_username = self.driver_wrapper.config.get_optional('Server', 'username')
         server_password = self.driver_wrapper.config.get_optional('Server', 'password')
         server_auth = '{}:{}@'.format(server_username, server_password) if server_username and server_password else ''
-        server_url = 'http://{}{}:{}'.format(server_auth, server_host, server_port)
+        server_url = '{}://{}{}:{}'.format(server_ssl, server_auth, server_host, server_port)
         return server_url
 
     def download_remote_video(self, remote_node, session_id, video_name):


### PR DESCRIPTION
Browserstack runs over https servers. Due to hardcore of "http" in Utils.get_server_url, it makes me imposible run tests without mocking this util (in fact it works!), this change will be great ;)