### PR TITLE
feat(type-hints): Type hint added to page_elements method to avoid fake warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ selenium>=2.53.6,<4         # web tests
 Appium-Python-Client>=0.24  # mobile tests
 six>=1.10.0
 screeninfo==0.3.1
+typing==3.7.4.1

--- a/toolium/pageelements/page_elements.py
+++ b/toolium/pageelements/page_elements.py
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from typing import List, Any
 
 from toolium.driver_wrapper import DriverWrappersPool
 from toolium.pageelements.button_page_element import Button
@@ -93,7 +94,7 @@ class PageElements(CommonObject):
         return self._web_elements
 
     @property
-    def page_elements(self):
+    def page_elements(self) -> List[Any]:
         """Find multiple PageElement using element locator
 
         :returns: list of page element objects

--- a/toolium/pageelements/page_elements.py
+++ b/toolium/pageelements/page_elements.py
@@ -94,7 +94,7 @@ class PageElements(CommonObject):
         return self._web_elements
 
     @property
-    def page_elements(self) -> List[Any]:
+    def page_elements(self):  # type: (...) -> List[Any]
         """Find multiple PageElement using element locator
 
         :returns: list of page element objects


### PR DESCRIPTION
PyCharm marks as warning lines like this:

InputTexts(*locator).page_elements[0].text = "hola"

because it thinks "InputTexts(*locator).page_elements[0]" in instance of "PageElement". The commit patchs this behaveour. Only cosmetics...