### PR TITLE
fix: VisualTest save_baseline check condition

### DIFF
--- a/toolium/test/test_visual_test.py
+++ b/toolium/test/test_visual_test.py
@@ -66,6 +66,7 @@ def driver_wrapper():
     config_files.set_output_directory(os.path.join(root_path, 'output'))
     driver_wrapper.configure(config_files)
     driver_wrapper.config.set('VisualTests', 'enabled', 'true')
+    driver_wrapper.config.set('VisualTests', 'save', 'true')
 
     yield driver_wrapper
 

--- a/toolium/visual_test.py
+++ b/toolium/visual_test.py
@@ -161,7 +161,7 @@ class VisualTest(object):
         DriverWrappersPool.visual_number += 1
 
         # Determine whether we should save the baseline image
-        if self.save_baseline or not os.path.exists(baseline_file):
+        if self.save_baseline and not os.path.exists(baseline_file):
             # Copy screenshot to baseline
             shutil.copyfile(output_file, baseline_file)
 


### PR DESCRIPTION
Found a bug using visual tests.

VisualTest "save" option was ignored due to an error on conditional