### PR TITLE
fix: typo in conf Server logs_types -> log_types

### DIFF
--- a/docs/remote_configuration.rst
+++ b/docs/remote_configuration.rst
@@ -18,7 +18,7 @@ section in properties.cfg file::
     password: SERVER_PASSWORD
     video_enabled: false
     logs_enabled: false
-    logs_types: all
+    log_types: all
 
 enabled
 ~~~~~~~
@@ -60,7 +60,7 @@ logs_enabled
 | *true*: webdriver and GGR logs are downloaded and saved to local files after test execution
 | *false*: webdriver and GGR logs are downloaded and saved to local files only if the test fails
 
-logs_types
+log_types
 ~~~~~~~~~~
 | Comma-separated list of webdriver log types that will be downloaded if remote test fails or if *logs_enabled* is true
 |

--- a/docs/tests_result_analysis.rst
+++ b/docs/tests_result_analysis.rst
@@ -63,7 +63,7 @@ the driver type, the webdriver will contain different log types, for instance, *
 *performance*, *profiler*, *logcat*, *bugreport*, etc.
 
 By default, when a test fails, toolium will download all log types available in current webdriver. But it can be also
-configured to download only a set of log types setting the property `log_types <https://toolium.readthedocs.io/en/latest/remote_configuration.html#logs-types>`_
+configured to download only a set of log types setting the property `log_types <https://toolium.readthedocs.io/en/latest/remote_configuration.html#log-types>`_
 in *[Server]* section in properties.cfg file ::
 
     [Server]

--- a/docs/tests_result_analysis.rst
+++ b/docs/tests_result_analysis.rst
@@ -63,11 +63,11 @@ the driver type, the webdriver will contain different log types, for instance, *
 *performance*, *profiler*, *logcat*, *bugreport*, etc.
 
 By default, when a test fails, toolium will download all log types available in current webdriver. But it can be also
-configured to download only a set of log types setting the property `logs_types <https://toolium.readthedocs.io/en/latest/remote_configuration.html#logs-types>`_
+configured to download only a set of log types setting the property `log_types <https://toolium.readthedocs.io/en/latest/remote_configuration.html#logs-types>`_
 in *[Server]* section in properties.cfg file ::
 
     [Server]
-    logs_types: client,server
+    log_types: client,server
 
 In order to download webdriver logs even if the test passes, configure the property `logs_enabled <https://toolium.readthedocs.io/en/latest/remote_configuration.html#logs-enabled>`_
 in *[Server]* section in properties.cfg file ::

--- a/toolium/test/conf/properties.cfg
+++ b/toolium/test/conf/properties.cfg
@@ -30,7 +30,7 @@ host: localhost
 port: 4444
 video_enabled: false
 logs_enabled: false
-logs_types: all
+log_types: all
 
 [VisualTests]
 enabled: false


### PR DESCRIPTION
## What does this PR do?
- Fix typo in documentation for configuration Server logs type
- Wrong documentation lead to invalid config, so toolium will get "all" log type as default

## Background context?
- Related to issuehttps://github.com/Telefonica/toolium/issues/178