### PR TITLE
fix: add list type to config driver convert property type method

### DIFF
--- a/toolium/config_driver.py
+++ b/toolium/config_driver.py
@@ -293,6 +293,8 @@ class ConfigDriver(object):
             return False
         elif str(value).startswith('{') and str(value).endswith('}'):
             return ast.literal_eval(value)
+        elif str(value).startswith('[') and str(value).endswith(']'):
+            return ast.literal_eval(value)
         else:
             try:
                 return int(value)

--- a/toolium/test/test_config_driver.py
+++ b/toolium/test/test_config_driver.py
@@ -507,6 +507,12 @@ def test_convert_property_type_str(config):
     assert config_driver._convert_property_type(value) == value
 
 
+def test_convert_property_type_list(config):
+    config_driver = ConfigDriver(config)
+    value = "[1, 2, 3]"
+    assert config_driver._convert_property_type(value) == [1, 2, 3]
+
+
 @mock.patch('toolium.config_driver.webdriver')
 def test_create_firefox_profile(webdriver_mock, config):
     config.add_section('Firefox')


### PR DESCRIPTION
Some Selenoid new capabilities must have type list (for example: hostsEntries). Toolium was converting list values to string and Selenoid can't process them. This PR includes a fix to convert values to list.