### PR TITLE
Nov 224147 automatic context selection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ v1.7.3
 
 *Release date: In development*
 
+- New config property 'automatic_context_selection' in [Driver] section for mobile tests with webview
+
+   | If it's false, the WebElement is searched using always NATIVE context
+   | If it's true, the WebElement is searched using context NATIVE or WEBVIEW depeding of the webview attribute value
+
 v1.7.2
 ------
 

--- a/toolium/pageelements/page_element.py
+++ b/toolium/pageelements/page_element.py
@@ -33,7 +33,7 @@ class PageElement(CommonObject):
                   or (selenium.webdriver.common.by.By or appium.webdriver.common.mobileby.MobileBy, str)
     """
 
-    def __init__(self, by, value, parent=None, order=None, wait=False, shadowroot=None):
+    def __init__(self, by, value, parent=None, order=None, wait=False, shadowroot=None, webview=False):
         """Initialize the PageElement object with the given locator components.
 
         If parent is not None, find_element will be performed over it, instead of
@@ -52,6 +52,7 @@ class PageElement(CommonObject):
         self.order = order  #: index value if the locator returns more than one element
         self.wait = wait  #: True if it must be loaded in wait_until_loaded method of the container page object
         self.shadowroot = shadowroot  #: CSS SELECTOR of the shadowroot for encapsulated element
+        self.webview = webview  #: True if element is in a mobile webview
         self.driver_wrapper = DriverWrappersPool.get_default_wrapper()  #: driver wrapper instance
         self.reset_object(self.driver_wrapper)
 
@@ -84,6 +85,11 @@ class PageElement(CommonObject):
     def _find_web_element(self):
         """Find WebElement using element locator and save it in _web_element attribute"""
         if not self._web_element or not self.config.getboolean_optional('Driver', 'save_web_element'):
+            # check context for mobile webviews
+            if self.driver_wrapper.is_mobile_test() and self.config.getboolean_optional('Driver',
+                                                                                        'automatic_context_selection'):
+                self._automatic_context_selection()
+
             # If the element is encapsulated we use the shadowroot tag in yaml (eg. Shadowroot: root_element_name)
             if self.shadowroot:
                 if self.locator[0] != By.CSS_SELECTOR:
@@ -99,6 +105,23 @@ class PageElement(CommonObject):
                 # Find elements and get the correct index or find a single element
                 self._web_element = base.find_elements(*self.locator)[self.order] if self.order else base.find_element(
                     *self.locator)
+
+    def _automatic_context_selection(self):
+        """Change context selection depending if the element is a webview"""
+        context_native = "NATIVE_APP"
+        context_webview = "WEBVIEW"
+        if self.webview:
+            if self.driver.context == context_native:
+                for _context in self.driver.contexts:
+                    if context_webview in _context:
+                        self.driver.switch_to.context(_context)
+                        break
+                else:
+                    raise Exception("WEBVIEW context not found")
+
+        else:
+            if self.driver.context != context_native:
+                self.driver.switch_to.context(context_native)
 
     def scroll_element_into_view(self):
         """Scroll element into view

--- a/toolium/pageelements/page_element.py
+++ b/toolium/pageelements/page_element.py
@@ -84,10 +84,10 @@ class PageElement(CommonObject):
 
     def _find_web_element(self):
         """Find WebElement using element locator and save it in _web_element attribute"""
-        if not self._web_element or not self.config.getboolean_optional('Driver', 'save_web_element'):
+        if not self._web_element or not self.driver_wrapper.config.getboolean_optional('Driver', 'save_web_element'):
             # check context for mobile webviews
-            if self.driver_wrapper.is_mobile_test() and self.config.getboolean_optional('Driver',
-                                                                                        'automatic_context_selection'):
+            if self.driver_wrapper.is_mobile_test() and self.driver_wrapper.config.\
+                    getboolean_optional('Driver', 'automatic_context_selection'):
                 self._automatic_context_selection()
 
             # If the element is encapsulated we use the shadowroot tag in yaml (eg. Shadowroot: root_element_name)

--- a/toolium/test/pageelements/test_derived_page_element.py
+++ b/toolium/test/pageelements/test_derived_page_element.py
@@ -75,6 +75,8 @@ def driver_wrapper():
     # Create a new wrapper
     driver_wrapper = DriverWrappersPool.get_default_wrapper()
     driver_wrapper.driver = mock.MagicMock()
+    driver_wrapper.is_mobile_test = mock.MagicMock(return_value=False)
+
 
     return driver_wrapper
 

--- a/toolium/test/pageelements/test_page_element.py
+++ b/toolium/test/pageelements/test_page_element.py
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 
 import mock
 import pytest
@@ -22,6 +23,7 @@ from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 
+from toolium.config_files import ConfigFiles
 from toolium.driver_wrapper import DriverWrapper
 from toolium.driver_wrappers_pool import DriverWrappersPool
 from toolium.pageelements import PageElement
@@ -57,6 +59,16 @@ def driver_wrapper():
 
     # Create a new wrapper
     driver_wrapper = DriverWrappersPool.get_default_wrapper()
+
+    # Configure wrapper
+    root_path = os.path.dirname(os.path.realpath(__file__))
+    config_files = ConfigFiles()
+    config_files.set_config_directory(os.path.join(root_path, 'conf'))
+    config_files.set_output_directory(os.path.join(root_path, 'output'))
+    config_files.set_config_log_filename('logging.conf')
+    DriverWrappersPool.configure_common_directories(config_files)
+    driver_wrapper.configure_properties()
+
     driver_wrapper.driver = mock.MagicMock()
     driver_wrapper.is_mobile_test = mock.MagicMock(return_value=False)
 
@@ -163,9 +175,7 @@ def test_get_web_element_in_test(driver_wrapper):
 
 
 def test_get_web_element_two_times_saving_enabled(driver_wrapper):
-    # Mock Driver.save_web_element = True
-    driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = True
+    driver_wrapper.config.set('Driver', 'save_web_element', 'true')
     login_page = RegisterPageObject(driver_wrapper)
     login_page.username.web_element
     login_page.username.web_element
@@ -175,9 +185,7 @@ def test_get_web_element_two_times_saving_enabled(driver_wrapper):
 
 
 def test_get_web_element_two_times_saving_disabled(driver_wrapper):
-    # Mock Driver.save_web_element = False
-    driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = False
+    driver_wrapper.config.set('Driver', 'save_web_element', 'false')
     login_page = RegisterPageObject(driver_wrapper)
     login_page.username.web_element
     login_page.username.web_element
@@ -376,7 +384,7 @@ def test_get_attribute(driver_wrapper):
 def test_automatic_context_selection_no_webview_context_available(driver_wrapper):
     driver_wrapper.is_mobile_test = mock.MagicMock(return_value=True)
     driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = True
+    driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.context = "NATIVE_APP"
     driver_wrapper.driver.contexts = ["NATIVE_APP"]
 
@@ -387,8 +395,7 @@ def test_automatic_context_selection_no_webview_context_available(driver_wrapper
 
 def test_automatic_context_selection_native_to_webview(driver_wrapper):
     driver_wrapper.is_mobile_test = mock.MagicMock(return_value=True)
-    driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = True
+    driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.context = "NATIVE_APP"
     driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
 
@@ -399,8 +406,7 @@ def test_automatic_context_selection_native_to_webview(driver_wrapper):
 
 def test_automatic_context_selection_webview_to_native(driver_wrapper):
     driver_wrapper.is_mobile_test = mock.MagicMock(return_value=True)
-    driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = True
+    driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.context = "WEBVIEW"
     driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
 
@@ -411,8 +417,7 @@ def test_automatic_context_selection_webview_to_native(driver_wrapper):
 
 def test_automatic_context_selection_native_to_native(driver_wrapper):
     driver_wrapper.is_mobile_test = mock.MagicMock(return_value=True)
-    driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = True
+    driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.context = "NATIVE_APP"
     driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
 
@@ -423,11 +428,20 @@ def test_automatic_context_selection_native_to_native(driver_wrapper):
 
 def test_automatic_context_selection_webview_to_webview(driver_wrapper):
     driver_wrapper.is_mobile_test = mock.MagicMock(return_value=True)
-    driver_wrapper.config = mock.MagicMock()
-    driver_wrapper.config.getboolean_optional.return_value = True
+    driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.context = "WEBVIEW"
     driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
 
     RegisterPageObject(driver_wrapper).element_webview.web_element
     driver_wrapper.driver.switch_to.context.assert_not_called()
+    driver_wrapper.driver.find_element.assert_called_once_with(By.ID, 'webview')
+
+
+def test_automatic_context_selection_disabled(driver_wrapper):
+    driver_wrapper.is_mobile_test = mock.MagicMock(return_value=True)
+    driver_wrapper.config.set('Driver', 'automatic_context_selection', 'false')
+    PageElement._automatic_context_selection = mock.MagicMock()
+
+    RegisterPageObject(driver_wrapper).element_webview.web_element
+    PageElement._automatic_context_selection.assert_not_called()
     driver_wrapper.driver.find_element.assert_called_once_with(By.ID, 'webview')

--- a/toolium/test/pageobjects/test_page_object.py
+++ b/toolium/test/pageobjects/test_page_object.py
@@ -140,6 +140,7 @@ def test_reset_object(driver_wrapper):
     mock_element_11 = mock.MagicMock(spec=WebElement)
     mock_element_12 = mock.MagicMock(spec=WebElement)
     driver_wrapper.driver.find_elements.side_effect = [[mock_element_11, mock_element_12]]
+    driver_wrapper.is_mobile_test = mock.MagicMock(return_value=False)
 
     page_object = RegisterPageObject(driver_wrapper)
 
@@ -186,6 +187,7 @@ def test_reset_object(driver_wrapper):
 
 
 def test_wait_until_loaded(driver_wrapper):
+    driver_wrapper.is_mobile_test = mock.MagicMock(return_value=False)
     page_object = RegisterPageObject(driver_wrapper).wait_until_loaded()
 
     # Check that all page elements with wait=True have a web element


### PR DESCRIPTION
New functionality for mobile tests with webviews. The context will be changed between WEBVIEW and NATIVE automatically.

New config property 'automatic_context_selection' in [Driver] section for mobile tests with webview

- If it's false, the WebElement is searched using always NATIVE context
- If it's true, the WebElement is searched using context NATIVE or WEBVIEW depending of the webview attribute value

Unit tests has been added and executed.