### PR TITLE
Include click action in InputText element

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ v1.7.3
 ------
 
 *Release date: In development*
+- Include click action in InputText element
 
 v1.7.2
 ------

--- a/toolium/pageelements/input_text_page_element.py
+++ b/toolium/pageelements/input_text_page_element.py
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from selenium.common.exceptions import StaleElementReferenceException
 from toolium.pageelements.page_element import PageElement
 
 
@@ -50,4 +50,16 @@ class InputText(PageElement):
         :returns: page element instance
         """
         self.web_element.clear()
+        return self
+
+    def click(self):
+        """Click the element
+
+        :returns: page element instance
+        """
+        try:
+            self.wait_until_clickable().web_element.click()
+        except StaleElementReferenceException:
+            # Retry if element has changed
+            self.web_element.click()
         return self


### PR DESCRIPTION
Include click() action in inputText element. Sometimes is necessary to show the keyboard for mobile tests.