### PR TITLE
Manage multiple webviews in mobile devices

### DIFF
--- a/toolium/pageelements/page_element.py
+++ b/toolium/pageelements/page_element.py
@@ -118,16 +118,15 @@ class PageElement(CommonObject):
         """Change context selection depending if the element is a webview for android devices"""
         if self.webview:
             if self.driver.context == PageElement.context_native:
-                for _context in self.driver.contexts:
-                    if PageElement.context_webview in _context:
-                        self.driver.switch_to.context(_context)
-                        if self.webview_index and (
-                                self.driver.current_window_handle !=
-                                self.driver.window_handles[self.webview_index]):
-                            self.driver.switch_to.window(self.driver.window_handles[self.webview_index])
-                        break
+                app_web_context = "{}_{}".format(PageElement.context_webview, self.driver.capabilities['appPackage'])
+                if app_web_context in self.driver.contexts:
+                    self.driver.switch_to.context(app_web_context)
+                    if self.webview_index and (
+                            self.driver.current_window_handle !=
+                            self.driver.window_handles[self.webview_index]):
+                        self.driver.switch_to.window(self.driver.window_handles[self.webview_index])
                 else:
-                    raise KeyError("WEBVIEW context not found")
+                    raise KeyError("App WEBVIEW context not found")
             elif self.webview_index and (
                     self.driver.current_window_handle != self.driver.window_handles[self.webview_index]):
                 self.driver.switch_to.window(self.driver.window_handles[self.webview_index])

--- a/toolium/test/pageelements/test_page_element.py
+++ b/toolium/test/pageelements/test_page_element.py
@@ -431,10 +431,11 @@ def test_android_automatic_context_selection_native_to_webview(driver_wrapper):
     driver_wrapper.is_ios_test = mock.MagicMock(return_value=False)
     driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.context = "NATIVE_APP"
-    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
+    driver_wrapper.driver.capabilities = {'appPackage': 'test.package.fake'}
+    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW_other.fake", "WEBVIEW_test.package.fake"]
 
     RegisterPageObject(driver_wrapper).element_webview.web_element
-    driver_wrapper.driver.switch_to.context.assert_called_once_with("WEBVIEW")
+    driver_wrapper.driver.switch_to.context.assert_called_once_with("WEBVIEW_test.package.fake")
     driver_wrapper.driver.find_element.assert_called_once_with(By.ID, 'webview')
 
 
@@ -538,13 +539,14 @@ def test_android_automatic_context_selection_multiwebview_native_to_default_webv
     driver_wrapper.is_ios_test = mock.MagicMock(return_value=False)
     driver_wrapper.config = mock.MagicMock()
     driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
+    driver_wrapper.driver.capabilities = {'appPackage': 'test.package.fake'}
     driver_wrapper.driver.context = "NATIVE_APP"
-    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
+    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW_test.package.fake", "WEBVIEW_other.fake"]
     driver_wrapper.driver.current_window_handle = "CDwindow-1"
     driver_wrapper.driver.window_handles = ["CDwindow-0", "CDwindow-1"]
 
     RegisterPageObject(driver_wrapper).element_multi_webview.web_element
-    driver_wrapper.driver.switch_to.context.assert_called_once_with("WEBVIEW")
+    driver_wrapper.driver.switch_to.context.assert_called_once_with("WEBVIEW_test.package.fake")
     driver_wrapper.driver.switch_to.window.assert_not_called()
     driver_wrapper.driver.find_element.assert_called_once_with(By.ID, 'multi_webview')
 
@@ -554,13 +556,14 @@ def test_android_automatic_context_selection_multiwebview_native_to_webview_2(dr
     driver_wrapper.is_ios_test = mock.MagicMock(return_value=False)
     driver_wrapper.config = mock.MagicMock()
     driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
+    driver_wrapper.driver.capabilities = {'appPackage': 'test.package.fake'}
     driver_wrapper.driver.context = "NATIVE_APP"
-    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW"]
+    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW_test.package.fake", "WEBVIEW_other.fake"]
     driver_wrapper.driver.current_window_handle = "CDwindow-0"
     driver_wrapper.driver.window_handles = ["CDwindow-0", "CDwindow-1"]
 
     RegisterPageObject(driver_wrapper).element_multi_webview.web_element
-    driver_wrapper.driver.switch_to.context.assert_called_once_with("WEBVIEW")
+    driver_wrapper.driver.switch_to.context.assert_called_once_with("WEBVIEW_test.package.fake")
     driver_wrapper.driver.switch_to.window.assert_called_once_with("CDwindow-1")
     driver_wrapper.driver.find_element.assert_called_once_with(By.ID, 'multi_webview')
 


### PR DESCRIPTION
during our tests we have detected that you can have several WEBVIEW contexts (e.g. the app webview context, stetho webview context). Also, the stetho context seems to change index of webview windows depending on the order of the scenarios being run.

Current code does select the first context whose identifier starts with "WEBVIEW". This might lead to selection of webview contexts not belonging to the app and thus, to failures in the selection of the window due to indexes changing. In order to fix this, the appPackage taken from the driver capabilites is added to the string that identifies the WEBVIEW context to be selected