### PR TITLE
Fix for visual test feature. Fixed mypy warnings.

### DIFF
--- a/toolium/visual_test.py
+++ b/toolium/visual_test.py
@@ -19,7 +19,6 @@ limitations under the License.
 from __future__ import division  # Python 2.7
 
 import datetime
-import itertools
 import logging
 import os
 import re
@@ -28,7 +27,6 @@ from io import BytesIO
 from os import path
 
 from selenium.common.exceptions import NoSuchElementException
-from six.moves import xrange  # Python 2 and 3 compatibility
 
 from toolium.driver_wrappers_pool import DriverWrappersPool
 from toolium.utils.path_utils import get_valid_filename, makedirs_safe
@@ -36,7 +34,7 @@ from toolium.utils.path_utils import get_valid_filename, makedirs_safe
 try:
     from needle.engines.perceptualdiff_engine import Engine as PerceptualEngine
     from needle.engines.pil_engine import Engine as PilEngine
-    from PIL import Image
+    from PIL import Image, ImageDraw
     from needle.engines.imagemagick_engine import Engine as MagickEngine
 except ImportError:
     pass
@@ -52,16 +50,20 @@ class VisualTest(object):
     css_name = 'VisualTests.css'  #: name of the css file
     report_name = 'VisualTests.html'  #: final visual report name
     driver_wrapper = None  #: driver wrapper instance
-    results = {'equal': 0, 'diff': 0, 'baseline': 0}  #: dict to save visual assert results
-    force = False  #: if True, screenshot is compared even if visual testing is disabled by configuration
+    results = {'equal': 0, 'diff': 0,
+               'baseline': 0}  #: dict to save visual assert results
+    force = False  #: if True, screenshot is compared even if
+    # visual testing is disabled by configuration
 
     def __init__(self, driver_wrapper=None, force=False):
-        self.driver_wrapper = driver_wrapper if driver_wrapper else DriverWrappersPool.get_default_wrapper()
+        self.driver_wrapper = driver_wrapper if driver_wrapper else DriverWrappersPool.get_default_wrapper()  # noqa E501
         self.force = force
-        if not self.driver_wrapper.config.getboolean_optional('VisualTests', 'enabled') and not self.force:
+        if not self.driver_wrapper.config.getboolean_optional(
+                'VisualTests', 'enabled') and not self.force:
             return
         if 'PerceptualEngine' not in globals():
-            raise Exception('The visual tests are enabled, but needle is not installed')
+            raise Exception(
+                'The visual tests are enabled, but needle is not installed')
 
         self.utils = self.driver_wrapper.utils
         self.logger = logging.getLogger(__name__)
@@ -69,27 +71,36 @@ class VisualTest(object):
 
         # Update baseline with real platformVersion value
         if '{platformVersion}' in self.driver_wrapper.baseline_name:
-            platform_version = self.driver_wrapper.driver.desired_capabilities['platformVersion']
-            baseline_name = self.driver_wrapper.baseline_name.replace('{platformVersion}', platform_version)
+            platform_version = self.driver_wrapper.driver.desired_capabilities[
+                'platformVersion']
+            baseline_name = self.driver_wrapper.baseline_name.replace(
+                '{platformVersion}', platform_version)
             self.driver_wrapper.baseline_name = baseline_name
-            self.driver_wrapper.visual_baseline_directory = os.path.join(DriverWrappersPool.visual_baseline_directory,
-                                                                         get_valid_filename(baseline_name))
+            self.driver_wrapper.visual_baseline_directory = os.path.join(
+                DriverWrappersPool.visual_baseline_directory,
+                get_valid_filename(baseline_name))
 
         self.baseline_directory = self.driver_wrapper.visual_baseline_directory
         self.engine = self._get_engine()
-        self.save_baseline = self.driver_wrapper.config.getboolean_optional('VisualTests', 'save')
+        self.save_baseline = self.driver_wrapper.config.getboolean_optional(
+            'VisualTests', 'save')
 
         # Create folders
         makedirs_safe(self.baseline_directory)
         makedirs_safe(self.output_directory)
 
         # Copy js, css and html template to output directory
-        dst_template_path = os.path.join(self.output_directory, self.report_name)
+        dst_template_path = os.path.join(self.output_directory,
+                                         self.report_name)
         if not os.path.exists(dst_template_path):
-            resources_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources')
-            orig_template_path = os.path.join(resources_path, self.template_name)
-            orig_javascript_path = os.path.join(resources_path, self.javascript_name)
-            dst_javascript_path = os.path.join(self.output_directory, self.javascript_name)
+            resources_path = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), 'resources')
+            orig_template_path = os.path.join(resources_path,
+                                              self.template_name)
+            orig_javascript_path = os.path.join(resources_path,
+                                                self.javascript_name)
+            dst_javascript_path = os.path.join(self.output_directory,
+                                               self.javascript_name)
             orig_css_path = os.path.join(resources_path, self.css_name)
             dst_css_path = os.path.join(self.output_directory, self.css_name)
             shutil.copyfile(orig_template_path, dst_template_path)
@@ -102,61 +113,95 @@ class VisualTest(object):
 
         :returns: engine instance
         """
-        engine_type = self.driver_wrapper.config.get_optional('VisualTests', 'engine', 'pil')
+        engine_type = self.driver_wrapper.config.get_optional('VisualTests',
+                                                              'engine', 'pil')
         if engine_type == 'perceptualdiff':
             engine = PerceptualEngine()
         elif engine_type == 'imagemagick' and 'MagickEngine' not in globals():
-            self.logger.warning("Engine '%s' not found, using pil instead. You need needle 0.4+ to use this engine.",
-                                engine_type)
+            self.logger.warning(
+                "Engine '%s' not found, using pil instead."
+                " You need needle 0.4+ to use this engine.",
+                engine_type)
             engine = PilEngine()
         elif engine_type == 'imagemagick':
             engine = MagickEngine()
         elif engine_type == 'pil':
             engine = PilEngine()
         else:
-            self.logger.warning("Engine '%s' not found, using pil instead. Review your properties.cfg file.",
-                                engine_type)
+            self.logger.warning(
+                "Engine '%s' not found, using pil instead."
+                " Review your properties.cfg file.",
+                engine_type)
             engine = PilEngine()
         return engine
 
-    def assert_screenshot(self, element, filename, file_suffix=None, threshold=0, exclude_elements=[]):
-        """Assert that a screenshot of an element is the same as a screenshot on disk, within a given threshold
+    def assert_screenshot(self, element, filename, file_suffix=None,
+                          threshold=0, exclude_elements=[]):
+        """Assert that a screenshot of an element is the same as a
+         screenshot on disk, within a given threshold
 
-        :param element: either a WebElement, PageElement or element locator as a tuple (locator_type, locator_value).
+        :param element: either a WebElement, PageElement or element locator
+         as a tuple (locator_type, locator_value).
                         If None, a full screenshot is taken.
-        :param filename: the filename for the screenshot, which will be appended with ``.png``
-        :param file_suffix: a string to be appended to the output filename with extra info about the test.
-        :param threshold: percentage threshold for triggering a test failure (value between 0 and 1)
-        :param exclude_elements: list of WebElements, PageElements or element locators as a tuple (locator_type,
-                                 locator_value) that must be excluded from the assertion
+        :param filename: the filename for the screenshot,
+         which will be appended with ``.png``
+        :param file_suffix: a string to be appended to the output filename
+         with extra info about the test.
+        :param threshold: percentage threshold for triggering
+         a test failure (value between 0 and 1)
+        :param exclude_elements: list of WebElements, PageElements or
+                                 element locators as a tuple (locator_type,
+                                 locator_value) that must be excluded
+                                 from the assertion
         """
-        if not self.driver_wrapper.config.getboolean_optional('VisualTests', 'enabled') and not self.force:
+        if not self.driver_wrapper.config.getboolean_optional(
+                'VisualTests', 'enabled') and not self.force:
             return
-        if not (isinstance(threshold, int) or isinstance(threshold, float)) or threshold < 0 or threshold > 1:
-            raise TypeError('Threshold must be a number between 0 and 1: {}'.format(threshold))
+        if not (isinstance(threshold, int) or isinstance(
+                threshold, float)) or threshold < 0 or threshold > 1:
+            raise TypeError(
+                'Threshold must be a number between 0 and 1: {}'.format(
+                    threshold))
 
         # Search elements
         web_element = self.utils.get_web_element(element)
         exclude_web_elements = []
         for exclude_element in exclude_elements:
             try:
-                exclude_web_elements.append(self.utils.get_web_element(exclude_element))
+                exclude_web_elements.append(
+                    self.utils.get_web_element(exclude_element))
             except NoSuchElementException as e:
-                self.logger.warning("Element to be excluded not found: %s", str(e))
+                self.logger.warning("Element to be excluded not found: %s",
+                                    str(e))
 
-        baseline_file = os.path.join(self.baseline_directory, '{}.png'.format(filename))
-        filename_with_suffix = '{0}__{1}'.format(filename, file_suffix) if file_suffix else filename
-        unique_name = '{0:0=2d}_{1}'.format(DriverWrappersPool.visual_number, filename_with_suffix)
+        baseline_file = os.path.join(self.baseline_directory,
+                                     '{}.png'.format(filename))
+        filename_with_suffix = '{0}__{1}'.format(
+            filename, file_suffix) if file_suffix else filename
+        unique_name = '{0:0=2d}_{1}'.format(
+            DriverWrappersPool.visual_number, filename_with_suffix)
         unique_name = '{}.png'.format(get_valid_filename(unique_name))
         output_file = os.path.join(self.output_directory, unique_name)
-        report_name = '{}<br>({})'.format(file_suffix, filename) if file_suffix else '-<br>({})'.format(filename)
+        report_name = '{}<br>({})'.format(
+            file_suffix, filename) if file_suffix else '-<br>({})'.format(
+            filename)
 
         # Get screenshot and modify it
-        img = Image.open(BytesIO(self.driver_wrapper.driver.get_screenshot_as_png()))
-        img = self.remove_scrolls(img)
-        img = self.mobile_resize(img)
-        img = self.exclude_elements(img, exclude_web_elements)
-        img = self.crop_element(img, web_element)
+        if web_element:
+            screenshot = web_element.screenshot_as_png
+        else:
+            screenshot = self.driver_wrapper.driver.get_screenshot_as_png()
+        img = Image.open(BytesIO(screenshot))
+        if not web_element:
+            window_size = self.driver_wrapper.driver.get_window_size()
+            resize_w = window_size.get('width')
+            resize_h = round(img.size[1] * (
+                    (window_size.get('width') * 100 / img.size[0]) / 100))
+            img = img.resize((resize_w, resize_h))
+            img = self.remove_scrolls(img)
+            img = self.mobile_resize(img)
+            img = self.exclude_elements(img, exclude_web_elements)
+        # img = self.crop_element(img, web_element)
         img.save(output_file)
         DriverWrappersPool.visual_number += 1
 
@@ -165,20 +210,31 @@ class VisualTest(object):
             # Copy screenshot to baseline
             shutil.copyfile(output_file, baseline_file)
 
-            if self.driver_wrapper.config.getboolean_optional('VisualTests', 'complete_report'):
-                self._add_result_to_report('baseline', report_name, output_file, None, 'Screenshot added to baseline')
+            if self.driver_wrapper.config.getboolean_optional(
+                    'VisualTests', 'complete_report'):
+                self._add_result_to_report(
+                    'baseline',
+                    report_name,
+                    output_file,
+                    None,
+                    'Screenshot added to baseline')
 
-            self.logger.debug("Visual screenshot '%s' saved in visualtests/baseline folder", filename)
+            self.logger.debug(
+                "Visual screenshot '%s' saved in visualtests/baseline folder",
+                filename)
         elif not os.path.exists(baseline_file):
             # Baseline should exist if save mode is not enabled
             error_message = "Baseline file not found: %s" % baseline_file
             self.logger.warning(error_message)
-            self._add_result_to_report('diff', report_name, output_file, None, 'Baseline file not found')
-            if self.driver_wrapper.config.getboolean_optional('VisualTests', 'fail') or self.force:
+            self._add_result_to_report('diff', report_name, output_file, None,
+                                       'Baseline file not found')
+            if self.driver_wrapper.config.getboolean_optional(
+                    'VisualTests', 'fail') or self.force:
                 raise AssertionError(error_message)
         else:
             # Compare the screenshots
-            self.compare_files(report_name, output_file, baseline_file, threshold)
+            self.compare_files(report_name, output_file, baseline_file,
+                               threshold)
 
     def get_scrolls_size(self):
         """Return Chrome and Explorer scrolls sizes if they are visible
@@ -188,12 +244,17 @@ class VisualTest(object):
         """
         scroll_x = 0
         scroll_y = 0
-        if self.utils.get_driver_name() in ['chrome', 'iexplore'] and not self.driver_wrapper.is_mobile_test():
-            scroll_height = self.driver_wrapper.driver.execute_script("return document.body.scrollHeight")
-            scroll_width = self.driver_wrapper.driver.execute_script("return document.body.scrollWidth")
-            window_height = self.driver_wrapper.driver.execute_script("return window.innerHeight")
-            window_width = self.driver_wrapper.driver.execute_script("return window.innerWidth")
-            scroll_size = 21 if self.utils.get_driver_name() == 'iexplore' else 17
+        browsers = ['chrome', 'iexplore']
+        if self.utils.get_driver_name() in browsers and not self.driver_wrapper.is_mobile_test():  # noqa E501
+            scroll_height = self.driver_wrapper.driver.execute_script(
+                "return document.body.scrollHeight")
+            scroll_width = self.driver_wrapper.driver.execute_script(
+                "return document.body.scrollWidth")
+            window_height = self.driver_wrapper.driver.execute_script(
+                "return window.innerHeight")
+            window_width = self.driver_wrapper.driver.execute_script(
+                "return window.innerWidth")
+            scroll_size = 21 if self.utils.get_driver_name() == 'iexplore' else 17  # noqa E501
             scroll_x = scroll_size if scroll_width > window_width else 0
             scroll_y = scroll_size if scroll_height > window_height else 0
         return {'x': scroll_x, 'y': scroll_y}
@@ -217,10 +278,11 @@ class VisualTest(object):
         :param img: image object
         :returns: modified image object
         """
-        if self.driver_wrapper.is_ios_test() or self.driver_wrapper.is_android_web_test():
+        if self.driver_wrapper.is_ios_test() or self.driver_wrapper.is_android_web_test():  # noqa E501
             scale = img.size[0] / self.utils.get_window_size()['width']
             if scale != 1:
-                new_image_size = (int(img.size[0] / scale), int(img.size[1] / scale))
+                new_image_size = (
+                    int(img.size[0] / scale), int(img.size[1] / scale))
                 img = img.resize(new_image_size, Image.ANTIALIAS)
         return img
 
@@ -230,21 +292,15 @@ class VisualTest(object):
         :param web_element: WebElement object
         :returns: tuple with element coordinates
         """
-        if not self.driver_wrapper.is_mobile_test():
-            scroll_x = self.driver_wrapper.driver.execute_script("return window.pageXOffset")
-            scroll_x = scroll_x if scroll_x else 0
-            scroll_y = self.driver_wrapper.driver.execute_script("return window.pageYOffset")
-            scroll_y = scroll_y if scroll_y else 0
-            offset_x = -scroll_x
-            offset_y = -scroll_y
-        else:
-            offset_x = 0
-            offset_y = self.utils.get_safari_navigation_bar_height()
 
         location = web_element.location
         size = web_element.size
-        return (int(location['x']) + offset_x, int(location['y'] + offset_y),
-                int(location['x'] + offset_x + size['width']), int(location['y'] + offset_y + size['height']))
+        return (
+            location.get('x') + size.get('width'),
+            location.get('y') + size['height'],
+            location.get('x'),
+            location.get('y')
+        )
 
     def crop_element(self, img, web_element):
         """Crop image to fit element
@@ -256,9 +312,10 @@ class VisualTest(object):
         if web_element:
             element_box = self.get_element_box(web_element)
             # Reduce element box if it is greater than image size
-            element_max_x = img.size[0] if element_box[2] > img.size[0] else element_box[2]
-            element_max_y = img.size[1] if element_box[3] > img.size[1] else element_box[3]
-            element_box = (element_box[0], element_box[1], element_max_x, element_max_y)
+            element_max_x = img.size[0] if element_box[2] > img.size[0] else element_box[2]  # noqa E501
+            element_max_y = img.size[1] if element_box[3] > img.size[1] else element_box[3]  # noqa E501
+            element_box = (
+                element_box[0], element_box[1], element_max_x, element_max_y)
             img = img.crop(element_box)
         return img
 
@@ -270,17 +327,10 @@ class VisualTest(object):
         """
         if web_elements and len(web_elements) > 0:
             img = img.convert("RGBA")
-            pixel_data = img.load()
-
             for web_element in web_elements:
                 element_box = self.get_element_box(web_element)
-                for x, y in itertools.product(xrange(element_box[0], element_box[2]),
-                                              xrange(element_box[1], element_box[3])):
-                    try:
-                        pixel_data[x, y] = (0, 0, 0, 255)
-                    except IndexError:
-                        pass
-
+                draw = ImageDraw.Draw(img)
+                draw.rectangle(element_box, fill="red")
         return img
 
     def compare_files(self, report_name, image_file, baseline_file, threshold):
@@ -294,27 +344,35 @@ class VisualTest(object):
         """
         width, height = Image.open(image_file).size
         if isinstance(self.engine, PilEngine):
-            # Pil needs a pixel number threshold instead of a percentage threshold
+            # Pil needs a pixel number threshold
+            # instead of a percentage threshold
             threshold = int(width * height * threshold)
         try:
-            if 'MagickEngine' in globals() and isinstance(self.engine, MagickEngine):
+            if 'MagickEngine' in globals() and isinstance(self.engine,
+                                                          MagickEngine):
                 # Workaround: ImageMagick hangs when images are not equal
-                assert (width, height) == Image.open(baseline_file).size, 'Image dimensions do not match'
+                assert (width, height) == Image.open(
+                    baseline_file).size, 'Image dimensions do not match'
             self.engine.assertSameFiles(image_file, baseline_file, threshold)
-            if self.driver_wrapper.config.getboolean_optional('VisualTests', 'complete_report'):
-                self._add_result_to_report('equal', report_name, image_file, baseline_file)
+            if self.driver_wrapper.config.getboolean_optional(
+                    'VisualTests', 'complete_report'):
+                self._add_result_to_report(
+                    'equal', report_name, image_file, baseline_file)
             return None
         except AssertionError as exc:
             diff_message = self._get_diff_message(str(exc), width * height)
-            self._add_result_to_report('diff', report_name, image_file, baseline_file, diff_message)
-            self.logger.warning("Visual error in '%s': %s", os.path.splitext(os.path.basename(baseline_file))[0],
-                                diff_message)
-            if self.driver_wrapper.config.getboolean_optional('VisualTests', 'fail') or self.force:
+            self._add_result_to_report('diff', report_name, image_file,
+                                       baseline_file, diff_message)
+            self.logger.warning("Visual error in '%s': %s", os.path.splitext(
+                os.path.basename(baseline_file))[0], diff_message)
+            if self.driver_wrapper.config.getboolean_optional(
+                    'VisualTests', 'fail') or self.force:
                 raise exc
             else:
                 return diff_message
 
-    def _add_result_to_report(self, result, report_name, image_file, baseline_file, message=''):
+    def _add_result_to_report(
+            self, result, report_name, image_file, baseline_file, message=''):
         """Add the result of a visual test to the html report
 
         :param result: comparation result (equal, diff, baseline)
@@ -324,7 +382,8 @@ class VisualTest(object):
         :param message: error message
         """
         self.results[result] += 1
-        row = self._get_html_row(result, report_name, image_file, baseline_file, message)
+        row = self._get_html_row(
+            result, report_name, image_file, baseline_file, message)
         self._add_data_to_report_before_tag(row, '</tbody>')
         self._update_report_summary()
 
@@ -334,7 +393,8 @@ class VisualTest(object):
         :param data: data to be added
         :param tag: data will be added before this tag
         """
-        with open(os.path.join(self.output_directory, self.report_name), "r+") as f:
+        with open(os.path.join(self.output_directory, self.report_name),
+                  "r+") as f:
             report = f.read()
             index = report.find(tag)
             report = report[:index] + data + report[index:]
@@ -343,22 +403,31 @@ class VisualTest(object):
 
     def _update_report_summary(self):
         """Update asserts counter in report"""
-        new_results = 'Visual asserts</b>: {} ({} failed)'.format(sum(self.results.values()), self.results['diff'])
-        with open(os.path.join(self.output_directory, self.report_name), "r+") as f:
+        new_results = 'Visual asserts</b>: {} ({} failed)'.format(
+            sum(self.results.values()), self.results['diff'])
+        with open(os.path.join(
+                self.output_directory, self.report_name), "r+") as f:
             report = f.read()
-            report = re.sub(r'Visual asserts</b>: [0-9]* \([0-9]* failed\)', new_results, report)
+            report = re.sub(
+                r'Visual asserts</b>: [0-9]* \([0-9]* failed\)',
+                new_results,
+                report)
             f.seek(0)
             f.write(report)
 
     def _add_summary_to_report(self):
         """Add visual data summary to the html report"""
-        summary = '<p><b>Execution date</b>: {}</p>'.format(datetime.datetime.now().strftime('%d/%m/%Y %H:%M:%S'))
-        summary += '<p><b>Baseline name</b>: {}</p>'.format(path.basename(self.baseline_directory))
-        summary += '<p><b>Visual asserts</b>: {} ({} failed)</p>'.format(sum(self.results.values()),
-                                                                         self.results['diff'])
+        summary = '<p><b>Execution date</b>: {}</p>'.format(
+            datetime.datetime.now().strftime('%d/%m/%Y %H:%M:%S'))
+        summary += '<p><b>Baseline name</b>: {}</p>'.format(
+            path.basename(self.baseline_directory))
+        summary += '<p><b>Visual asserts</b>: {} ({} failed)</p>'.format(
+            sum(self.results.values()),
+            self.results['diff'])
         self._add_data_to_report_before_tag(summary, '</div>')
 
-    def _get_html_row(self, result, report_name, image_file, baseline_file, message=''):
+    def _get_html_row(
+            self, result, report_name, image_file, baseline_file, message=''):
         """Create the html row with the result of a visual test
 
         :param result: comparation result (equal, diff, baseline)
@@ -381,7 +450,8 @@ class VisualTest(object):
 
         # Create diff column
         diff_file = image_file.replace('.png', '.diff.png')
-        diff_col = self._get_img_element(diff_file, message) if os.path.exists(diff_file) else message
+        diff_col = self._get_img_element(diff_file, message) if os.path.exists(
+            diff_file) else message
 
         row += '<td>' + diff_col + '</td>'
         row += '</tr>'
@@ -396,8 +466,10 @@ class VisualTest(object):
         """
         if not image_file:
             return ''
-        image_file_path = path.relpath(image_file, self.output_directory).replace('\\', '/')
-        return '<img src="{}" title="{}"/>'.format(image_file_path, image_title)
+        image_file_path = path.relpath(
+            image_file, self.output_directory).replace('\\', '/')
+        return '<img src="{}" title="{}"/>'.format(
+            image_file_path, image_title)
 
     @staticmethod
     def _get_diff_message(message, image_size):
@@ -412,11 +484,12 @@ class VisualTest(object):
             # Images are equal
             return ''
         elif message == '' or 'Image dimensions do not match' in message:
-            # Different sizes in pil (''), perceptualdiff or imagemagick engines
+            # Different sizes in pil (''),
+            # perceptualdiff or imagemagick engines
             return 'Image dimensions do not match'
 
         # Check pil engine message
-        m = re.search('\(by a distance of (.*)\)', message)
+        m = re.search('\\(by a distance of (.*)\\)', message)
         if m:
             return 'Distance of %0.8f' % (float(m.group(1)) / image_size)
 


### PR DESCRIPTION
There was a problem with excluding elements functionality. Even if I tried to launch example tests from https://github.com/Telefonica/toolium-examples the tool does not exclude expected part of the screen. Also there was a problem with assert_screenshot for the specific element (not a full page).
 
<img width="880" alt="Zrzut ekranu 2021-02-26 o 11 44 44" src="https://user-images.githubusercontent.com/17065568/109290637-2897e400-7828-11eb-951f-8a361750b621.png">


Also I fixed PEP-8 warnings.