### PR TITLE
NOV-226397 fix dynamic environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ v1.9.1
 - Move CI from Travis to Github Actions
 - Fix string conversion in dataset utilities
 - Add upper/lower conversion to replace param method
+- Fix report when an error happens in the Dynamic Environment
 
 v1.9.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ v2.0.0
 - Update deprecated methods to fix warnings in python3 execution
 - Move *get_valid_filename* and *makedirs_safe* methods from *toolium.path_utils* to *toolium.utils.path_utils*
 - Move *Utils* class from *toolium.utils* to *toolium.utils.driver_utils*
+- Fix report when an error happens in the Dynamic Environment
 
 v1.9.2
 ------
@@ -27,7 +28,6 @@ v1.9.1
 - Move CI from Travis to Github Actions
 - Fix string conversion in dataset utilities
 - Add upper/lower conversion to replace param method
-- Fix report when an error happens in the Dynamic Environment
 
 v1.9.0
 ------

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -216,9 +216,9 @@ class DynamicEnvironment:
                     context.execute_steps(u'''%s%s''' % (GIVEN_PREFIX, self.__remove_prefix(item)))
                     self.logger.debug(u'step defined in pre-actions: %s' % repr(item))
                 except Exception as exc:
-                    if action in [ACTIONS_BEFORE_FEATURE] or action in [ACTIONS_AFTER_FEATURE]:
+                    if action in [ACTIONS_BEFORE_FEATURE, ACTIONS_AFTER_FEATURE]:
                         self.feature_error = True
-                    elif action in [ACTIONS_BEFORE_SCENARIO] or action in [ACTIONS_AFTER_SCENARIO]:
+                    elif action in [ACTIONS_BEFORE_SCENARIO, ACTIONS_AFTER_SCENARIO]:
                         self.scenario_error = True
                     self.logger.error(exc)
                     self.error_exception = exc

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -216,9 +216,9 @@ class DynamicEnvironment:
                     context.execute_steps(u'''%s%s''' % (GIVEN_PREFIX, self.__remove_prefix(item)))
                     self.logger.debug(u'step defined in pre-actions: %s' % repr(item))
                 except Exception as exc:
-                    if action in [ACTIONS_BEFORE_FEATURE]:
+                    if action in [ACTIONS_BEFORE_FEATURE] or action in [ACTIONS_AFTER_FEATURE]:
                         self.feature_error = True
-                    elif action in [ACTIONS_BEFORE_SCENARIO]:
+                    elif action in [ACTIONS_BEFORE_SCENARIO] or action in [ACTIONS_AFTER_SCENARIO]:
                         self.scenario_error = True
                     self.logger.error(exc)
                     self.error_exception = exc
@@ -286,7 +286,8 @@ class DynamicEnvironment:
         if self.reset_error_status():
             context.feature.reset()
             for scenario in context.feature.walk_scenarios():
-                context.dyn_env.fail_first_step_precondition_exception(scenario)
+                if scenario.should_run(context.config):
+                    context.dyn_env.fail_first_step_precondition_exception(scenario)
             raise Exception("Preconditions failed during the execution")
 
     def fail_first_step_precondition_exception(self, scenario):

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -216,9 +216,9 @@ class DynamicEnvironment:
                     context.execute_steps(u'''%s%s''' % (GIVEN_PREFIX, self.__remove_prefix(item)))
                     self.logger.debug(u'step defined in pre-actions: %s' % repr(item))
                 except Exception as exc:
-                    if action in [ACTIONS_BEFORE_FEATURE, ACTIONS_AFTER_FEATURE]:
+                    if action in [ACTIONS_BEFORE_FEATURE]:
                         self.feature_error = True
-                    elif action in [ACTIONS_BEFORE_SCENARIO, ACTIONS_AFTER_SCENARIO]:
+                    elif action in [ACTIONS_BEFORE_SCENARIO]:
                         self.scenario_error = True
                     self.logger.error(exc)
                     self.error_exception = exc


### PR DESCRIPTION
Actual behaviour when an error in Dynamic Environment happens:

- **Error in Actions Before Feature:** when this happens all the scenarios are marked as failed (not only the scenarios that matches with the tags)
- **Error in Actions Before each Scenario:** when this happens all the scenarios are marked as failed (not only the scenarios that matches with the tags)

Proposal:

- **Error in Actions Before Feature:** when this happens all the scenarios will be marked as failed (only the scenarios that matches with the tags)
- **Error in Actions Before each Scenario:** when this happens all the scenarios will be marked as failed (only the scenarios that matches with the tags)