### PR TITLE
NOV-227875 InputText with webview mode getting the text value

### DIFF
--- a/toolium/pageelements/input_text_page_element.py
+++ b/toolium/pageelements/input_text_page_element.py
@@ -26,7 +26,7 @@ class InputText(PageElement):
 
         :returns: element text value
         """
-        if self.driver_wrapper.is_web_test():
+        if self.driver_wrapper.is_web_test() or self.webview:
             return self.web_element.get_attribute("value")
         elif self.driver_wrapper.is_ios_test():
             return self.web_element.get_attribute("label")


### PR DESCRIPTION
The text getter was not working for android/ios in webview mode. The webview mode check has been added to the get it from value as in web.