### PR TITLE
fix: prevent JSON boolean/null from being converted to Python boolean/None

### DIFF
--- a/toolium/test/utils/test_dataset_utils.py
+++ b/toolium/test/utils/test_dataset_utils.py
@@ -236,9 +236,9 @@ def test_replace_param_type_inference():
     param = replace_param('0.5')  # float
     assert param == 0.5
     param = replace_param('True')  # boolean
-    assert param == True
+    assert param is True
     param = replace_param('None')  # None
-    assert param == None
+    assert param is None
     param = replace_param("{'a':'test1', 'b':True, 'c':None}")  # dict
     assert param == {'a': 'test1', 'b': True, 'c': None}
     param = replace_param("['1', True,None]")  # list

--- a/toolium/test/utils/test_dataset_utils.py
+++ b/toolium/test/utils/test_dataset_utils.py
@@ -235,6 +235,10 @@ def test_replace_param_type_inference():
     assert param == 1234
     param = replace_param('0.5')  # float
     assert param == 0.5
+    param = replace_param('True')  # boolean
+    assert param == True
+    param = replace_param('None')  # None
+    assert param == None
     param = replace_param("{'a':'test1', 'b':True, 'c':None}")  # dict
     assert param == {'a': 'test1', 'b': True, 'c': None}
     param = replace_param("['1', True,None]")  # list
@@ -243,6 +247,10 @@ def test_replace_param_type_inference():
     assert param == {'a': 'test1', 'b': True, 'c': None}
     param = replace_param('["1", true, null]')  # JSON list
     assert param == ['1', True, None]
+    param = replace_param('true')  # JSON boolean
+    assert param == 'true'
+    param = replace_param('null')  # JSON null
+    assert param == 'null'
 
 
 def test_replace_param_type_inference_disabled():
@@ -250,6 +258,10 @@ def test_replace_param_type_inference_disabled():
     assert param == '1234'
     param = replace_param('0.5', infer_param_type=False)
     assert param == '0.5'
+    param = replace_param('True', infer_param_type=False)
+    assert param == 'True'
+    param = replace_param('None', infer_param_type=False)
+    assert param == 'None'
     param = replace_param("{'a':'test1', 'b':True, 'c':None}", infer_param_type=False)
     assert param == "{'a':'test1', 'b':True, 'c':None}"
     param = replace_param("['1', True, None]", infer_param_type=False)

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -250,10 +250,10 @@ def _infer_param_type(param):
     try:
         new_param = literal_eval(param)
     except Exception:
-        if param.startswith('{') or param.startswith('['):
-            # it may still be a JSON object/list that can be converted to a dict/list
-            try:
+        # it may still be a JSON object/list that can be converted to a dict/list
+        try:
+            if param.startswith('{') or param.startswith('['):
                 new_param = json.loads(param)
-            except Exception:
-                pass
+        except Exception:
+            pass
     return new_param


### PR DESCRIPTION
Prevent JSON boolean/null from being converted to Python boolean/None