### PR TITLE
fix: fix doc compilation errors in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ v2.2.1
 
 - Add support for Python 3.10
 - Remove Python 3.5 support (Python 3.5 reached the end of its life on September 13th, 2020)
+- Move code quality check from codacy to codeclimate
+- Upgrade Sphinx version from 3.* to 4.* to fix doc compilation errors in readthedocs
 
 v2.2.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -7,12 +7,12 @@ Toolium is a Python wrapper tool of Selenium and Appium libraries to test web an
 project. It provides a way of choosing and configuring the driver through a configuration file, implements a Page Object
 pattern and includes a simple visual testing solution.
 
-.. |Build Status| image:: https://github.com/Telefonica/toolium/workflows/build/badge.svg
-   :target: https://github.com/Telefonica/toolium/actions
+.. |Build Status| image:: https://github.com/Telefonica/toolium/workflows/build/badge.svg?branch=master
+   :target: https://github.com/Telefonica/toolium/actions?query=branch%3Amaster
 .. |Documentation Status| image:: https://readthedocs.org/projects/toolium/badge/?version=latest
    :target: http://toolium.readthedocs.org/en/latest
 .. |Coverage Status| image:: https://coveralls.io/repos/Telefonica/toolium/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/github/Telefonica/toolium
+   :target: https://coveralls.io/github/Telefonica/toolium?branch=master
 .. |CodeClimate| image:: https://api.codeclimate.com/v1/badges/3e5773b2e5272b546f8a/maintainability
    :target: https://codeclimate.com/github/Telefonica/toolium/maintainability
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==4.*
+sphinx_rtd_theme==1.*
+readthedocs-sphinx-search==0.1.*

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-Sphinx==3.*
 lettuce==0.2.23
 pytest==6.*
 coverage==5.*
@@ -6,6 +5,5 @@ coveralls==3.*
 mock==3.*
 requests-mock==1.*
 needle==0.5.0
-docutils==0.16  # imposed by Sphinx 3.*
 Pygments==2.*
 flake8==3.*


### PR DESCRIPTION
* Upgrade Sphinx version from 3.* to 4.*
* Move doc requirements to an specific file
* Add readthedocs configuration in yaml file instead of using default conf
* Update github actions and coverage links to master branch to unify README.rst links

URL to check that readthedocs now works with this PR: https://toolium.readthedocs.io/en/fix-readthedocs/changelog.html