### PR TITLE
fix: poeditor config not available detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v2.4.0
 *Release date: In development*
 
 - Add set_file_path and set_base64_path functions to dataset module, to set base paths for FILE and BASE64 mappings
+- Fix detection of POEditor configuration not available
 
 v2.3.0
 ------

--- a/toolium/test/utils/test_poeditor.py
+++ b/toolium/test/utils/test_poeditor.py
@@ -18,7 +18,7 @@ limitations under the License.
 
 import mock
 
-from toolium.utils.poeditor import get_valid_lang
+from toolium.utils.poeditor import get_valid_lang, load_poeditor_texts
 
 
 def test_poe_lang_param():
@@ -31,3 +31,17 @@ def test_poe_lang_param():
     assert get_valid_lang(context, 'es') == 'es'
     assert get_valid_lang(context, 'es-es') == 'es'
     assert get_valid_lang(context, 'es-co') == 'es-co'
+
+
+class ContextLogger(object):
+    def __init__(self):
+        self.logger = mock.MagicMock()
+
+
+def test_poe_texts_load_without_api_token():
+    """
+    Verification of POEditor texts load abortion when api_token is not configured
+    """
+    context = ContextLogger()
+    load_poeditor_texts(context)
+    context.logger.info.assert_called_with("POEditor is not configured")

--- a/toolium/utils/poeditor.py
+++ b/toolium/utils/poeditor.py
@@ -329,5 +329,8 @@ def get_poeditor_api_token(context):
     try:
         api_token = os.environ['poeditor_api_token']
     except KeyError:
-        api_token = map_param('[CONF:poeditor.api_token]', context)
+        try:
+            api_token = context.project_config['poeditor']['api_token']
+        except (AttributeError, KeyError):
+            api_token = None
     return api_token


### PR DESCRIPTION
Better handling of the error due to load_poeditor_texts() function being called when POEditor configuration is not available.