### PR TITLE
chore: resolve datetime offsets within parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ v2.5.1
 *Release date: In development*
 
 - Update map_param method to allow recursive replacements
-- Resolve multiple expressions in the same param
+- Update replace_param function to allow multiple date expressions in the same param
 
 v2.5.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v2.5.1
 *Release date: In development*
 
 - Update map_param method to allow recursive replacements
+- Resolve multiple expressions in the same param
 
 v2.5.0
 ------

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -192,28 +192,28 @@ def test_replace_param_now_offset():
     param = replace_param('[NOW + 5 MINUTES]', language='es')
     assert param == datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=5), '%d/%m/%Y %H:%M:%S')
-    
-    
+
+
 def test_replace_param_today_offset_and_more():
     param = replace_param('The day [TODAY - 1 DAYS] was yesterday', language='es')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
     assert param == f'The day {offset_date} was yesterday'
-    
-    
+
+
 def test_replace_param_today_offset_and_more_not_spanish():
     param = replace_param('The day [TODAY - 1 DAYS] was yesterday', language='it')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.today() - datetime.timedelta(days=1), '%Y/%m/%d')
     assert param == f'The day {offset_date} was yesterday'
-    
+
 
 def test_replace_param_now_offset_and_more():
     param = replace_param('I will arrive at [NOW + 10 MINUTES] tomorrow', language='es')
     offset_datetime = datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%d/%m/%Y %H:%M:%S')
     assert param == f'I will arrive at {offset_datetime} tomorrow'
-    
+
 
 def test_replace_param_now_offset_and_more_not_spanish():
     param = replace_param('I will arrive at [NOW + 10 MINUTES] tomorrow', language='it')
@@ -227,14 +227,14 @@ def test_replace_param_today_offset_and_more_with_extra_spaces():
     offset_date = datetime.datetime.strftime(
         datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
     assert param == f'The day {offset_date} was yesterday'
-    
+
 
 def test_replace_param_today_offset_and_more_at_the_end():
     param = replace_param('Yesterday was [TODAY - 1 DAYS]', language='es')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
     assert param == f'Yesterday was {offset_date}'
-    
+
 
 def test_replace_param_today_offset_and_more_at_the_beginning():
     param = replace_param('[TODAY - 1 DAYS] is yesterday', language='es')
@@ -244,7 +244,8 @@ def test_replace_param_today_offset_and_more_at_the_beginning():
 
 
 def test_replace_param_today_offsets_and_more():
-    param = replace_param('The day [TODAY - 1 DAYS] was yesterday and I have an appointment at [NOW + 10 MINUTES]', language='es')
+    param = replace_param(
+        'The day [TODAY - 1 DAYS] was yesterday and I have an appointment at [NOW + 10 MINUTES]', language='es')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
     offset_datetime = datetime.datetime.strftime(

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -192,6 +192,55 @@ def test_replace_param_now_offset():
     param = replace_param('[NOW + 5 MINUTES]', language='es')
     assert param == datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=5), '%d/%m/%Y %H:%M:%S')
+    
+    
+def test_replace_param_today_offset_and_more():
+    param = replace_param('The day [TODAY - 1 DAYS] was yesterday', language='es')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
+    assert param == f'The day {offset_date} was yesterday'
+    
+    
+def test_replace_param_today_offset_and_more_not_spanish():
+    param = replace_param('The day [TODAY - 1 DAYS] was yesterday', language='it')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.today() - datetime.timedelta(days=1), '%Y/%m/%d')
+    assert param == f'The day {offset_date} was yesterday'
+    
+
+def test_replace_param_now_offset_and_more():
+    param = replace_param('I will arrive at [NOW + 10 MINUTES] tomorrow', language='es')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%d/%m/%Y %H:%M:%S')
+    assert param == f'I will arrive at {offset_datetime} tomorrow'
+    
+
+def test_replace_param_now_offset_and_more_not_spanish():
+    param = replace_param('I will arrive at [NOW + 10 MINUTES] tomorrow', language='it')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y/%m/%d %H:%M:%S')
+    assert param == f'I will arrive at {offset_datetime} tomorrow'
+
+
+def test_replace_param_today_offset_and_more_with_extra_spaces():
+    param = replace_param('The day [TODAY    - 1    DAYS ] was yesterday', language='es')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
+    assert param == f'The day {offset_date} was yesterday'
+    
+
+def test_replace_param_today_offset_and_more_at_the_end():
+    param = replace_param('Yesterday was [TODAY - 1 DAYS]', language='es')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
+    assert param == f'Yesterday was {offset_date}'
+    
+
+def test_replace_param_today_offset_and_more_at_the_beginning():
+    param = replace_param('[TODAY - 1 DAYS] is yesterday', language='es')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
+    assert param == f'{offset_date} is yesterday'
 
 
 def test_replace_param_str_int():

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -243,6 +243,15 @@ def test_replace_param_today_offset_and_more_at_the_beginning():
     assert param == f'{offset_date} is yesterday'
 
 
+def test_replace_param_today_offsets_and_more():
+    param = replace_param('The day [TODAY - 1 DAYS] was yesterday and I have an appointment at [NOW + 10 MINUTES]', language='es')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.today() - datetime.timedelta(days=1), '%d/%m/%Y')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%d/%m/%Y %H:%M:%S')
+    assert param == f'The day {offset_date} was yesterday and I have an appointment at {offset_datetime}'
+
+
 def test_replace_param_str_int():
     param = replace_param('[STR:28]')
     assert type(param) == str

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -140,6 +140,19 @@ def _replace_param_type(param):
     return new_param, param_replaced
 
 
+def _find_param_date_expressions(param):
+    """
+    Finds in a param a date expression. 
+    For example, for a param like "it happened on [NOW - 1 MONTH] of the last year", this method returns
+    the string "[NOW - 1 MONTH]"
+    
+    :param param: parameter value
+    :param language: language to configure date format for NOW and TODAY
+    :return: the specific text within the param holding a date expression
+    """
+    return re.findall(r'\[(?:NOW|TODAY)\s*[\+|-]\s*\d+\s*\w+\s*\]', param)
+
+
 def _replace_param_replacement(param, language):
     """
     Replace param with a new param value.
@@ -163,6 +176,12 @@ def _replace_param_replacement(param, language):
         '[NOW]': str(datetime.datetime.utcnow().strftime(date_format)),
         '[TODAY]': str(datetime.datetime.utcnow().strftime(date_day_format))
     }
+    
+    # append date expressions found in param to the replacement dict 
+    date_expressions = _find_param_date_expressions(param)
+    for date_expr in date_expressions:
+        replacements[date_expr] = _replace_param_date(date_expr, language)[0]
+        
     new_param = param
     param_replaced = False
     for key in replacements.keys():

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -97,7 +97,7 @@ def replace_param(param, language='es', infer_param_type=True):
 
     if not param_replaced:
         # Replacements that return new strings that can be transformed later
-        new_param, param_replaced = _replace_param_replacement(new_param, language)
+        new_param = _replace_param_replacement(new_param, language)
 
         # String transformations that do not allow type inference
         new_param, param_replaced = _replace_param_transform_string(new_param)
@@ -181,12 +181,10 @@ def _replace_param_replacement(param, language):
         replacements[date_expr] = _replace_param_date(date_expr, language)[0]
         
     new_param = param
-    param_replaced = False
     for key in replacements.keys():
         if key in new_param:
             new_param = new_param.replace(key, replacements[key])
-            param_replaced = True
-    return new_param, param_replaced
+    return new_param
 
 
 def _replace_param_transform_string(param):

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -98,8 +98,6 @@ def replace_param(param, language='es', infer_param_type=True):
     if not param_replaced:
         # Replacements that return new strings that can be transformed later
         new_param, param_replaced = _replace_param_replacement(new_param, language)
-        if not param_replaced:
-            new_param, param_replaced = _replace_param_date(new_param, language)
 
         # String transformations that do not allow type inference
         new_param, param_replaced = _replace_param_transform_string(new_param)
@@ -185,10 +183,9 @@ def _replace_param_replacement(param, language):
     new_param = param
     param_replaced = False
     for key in replacements.keys():
-        if key in param:
-            new_param = param.replace(key, replacements[key])
+        if key in new_param:
+            new_param = new_param.replace(key, replacements[key])
             param_replaced = True
-            break
     return new_param, param_replaced
 
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -97,7 +97,7 @@ def replace_param(param, language='es', infer_param_type=True):
 
     if not param_replaced:
         # Replacements that return new strings that can be transformed later
-        new_param = _replace_param_replacement(new_param, language)
+        new_param, _ = _replace_param_replacement(new_param, language)
 
         # String transformations that do not allow type inference
         new_param, param_replaced = _replace_param_transform_string(new_param)
@@ -181,10 +181,12 @@ def _replace_param_replacement(param, language):
         replacements[date_expr] = _replace_param_date(date_expr, language)[0]
         
     new_param = param
+    param_replaced = False
     for key in replacements.keys():
         if key in new_param:
             new_param = new_param.replace(key, replacements[key])
-    return new_param
+            param_replaced = True
+    return new_param, param_replaced
 
 
 def _replace_param_transform_string(param):


### PR DESCRIPTION
resolution of expressions like [TODAY + 1] are now considered, not only if the whole param is the expression but also if the param contains it as part of a longer string.

This change permits the replacement of several placeholders in the same parameter