### PR TITLE
chore: permit custom format for the NOW placeholder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ v2.5.1
 - Update map_param method to allow recursive replacements
 - Update replace_param function to allow multiple date expressions in the same param
 - Fix error message to show parent locator instead of object reference when an element is not found
+- Update replace_param function to allow NOW datetime expressions including ISO-8601 formats
 
 v2.5.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ v2.5.1
 - Update map_param method to allow recursive replacements
 - Update replace_param function to allow multiple date expressions in the same param
 - Fix error message to show parent locator instead of object reference when an element is not found
-- Update replace_param function to allow NOW datetime expressions including ISO-8601 formats
+- Update replace_param function to allow NOW datetime expressions with arbitrary formats accepted by datetime.strftime
 
 v2.5.0
 ------

--- a/docs/bdd_integration.rst
+++ b/docs/bdd_integration.rst
@@ -169,8 +169,10 @@ functions or check the :ref:`dataset <dataset>` module for more implementation d
 * :code:`[TIMESTAMP]`: Generates a timestamp from the current time
 * :code:`[DATETIME]`: Generates a datetime from the current time
 * :code:`[NOW]`: Similar to DATETIME without milliseconds; the format depends on the language
+* :code:`[NOW(%Y-%m-%dT%H:%M:%SZ)]`: Same as NOW but using an specific format by the python strftime function of the datetime module
 * :code:`[NOW + 2 DAYS]`: Similar to NOW but two days later
 * :code:`[NOW - 1 MINUTES]`: Similar to NOW but one minute earlier
+* :code:`[NOW(%Y-%m-%dT%H:%M:%SZ) - 7 DAYS]`: Similar to NOW but seven days before and with the indicated format
 * :code:`[TODAY]`: Similar to NOW without time; the format depends on the language
 * :code:`[TODAY + 2 DAYS]`: Similar to NOW, but two days later
 * :code:`[STR:xxxx]`: Cast xxxx to a string

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -188,10 +188,21 @@ def test_replace_param_now_not_spanish():
     assert param == datetime.datetime.utcnow().strftime('%Y/%m/%d %H:%M:%S')
 
 
+def test_replace_param_now_with_format():
+    param = replace_param('[NOW(\'%Y-%m-%dT%H:%M:%SZ\')]')
+    assert param == datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
 def test_replace_param_now_offset():
     param = replace_param('[NOW + 5 MINUTES]', language='es')
     assert param == datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=5), '%d/%m/%Y %H:%M:%S')
+
+
+def test_replace_param_now_offset_with_format():
+    param = replace_param('[NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 5 MINUTES]')
+    assert param == datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=5), '%Y-%m-%dT%H:%M:%SZ')
 
 
 def test_replace_param_today_offset_and_more():
@@ -220,6 +231,27 @@ def test_replace_param_now_offset_and_more_not_spanish():
     offset_datetime = datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y/%m/%d %H:%M:%S')
     assert param == f'I will arrive at {offset_datetime} tomorrow'
+
+
+def test_replace_param_now_offset_with_format_and_more():
+    param = replace_param('I will arrive at [NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 10 MINUTES] tomorrow')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y-%m-%dT%H:%M:%SZ')
+    assert param == f'I will arrive at {offset_datetime} tomorrow'
+
+
+def test_replace_param_now_offset_with_format_and_more_language_is_irrelevant():
+    param = replace_param('I will arrive at [NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 10 MINUTES] tomorrow', language='ru')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y-%m-%dT%H:%M:%SZ')
+    assert param == f'I will arrive at {offset_datetime} tomorrow'
+
+
+def test_replace_param_today_offset_with_format_and_more_with_extra_spaces():
+    param = replace_param('The date [NOW(\'%Y-%m-%dT%H:%M:%SZ\')   - 1    DAYS ] was yesterday')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.utcnow() - datetime.timedelta(days=1), '%Y-%m-%dT%H:%M:%SZ')
+    assert param == f'The date {offset_date} was yesterday'
 
 
 def test_replace_param_today_offset_and_more_with_extra_spaces():
@@ -251,6 +283,28 @@ def test_replace_param_today_offsets_and_more():
     offset_datetime = datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%d/%m/%Y %H:%M:%S')
     assert param == f'The day {offset_date} was yesterday and I have an appointment at {offset_datetime}'
+
+
+def test_replace_param_now_offsets_with_format_and_more():
+    param = replace_param(
+        'The date [NOW(\'%Y-%m-%dT%H:%M:%SZ\') - 1 DAYS] was yesterday '
+        'and I have an appointment at [NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 10 MINUTES]')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.utcnow() - datetime.timedelta(days=1), '%Y-%m-%dT%H:%M:%SZ')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y-%m-%dT%H:%M:%SZ')
+    assert param == f'The date {offset_date} was yesterday and I have an appointment at {offset_datetime}'
+
+
+def test_replace_param_now_offsets_with_and_without_format_and_more():
+    param = replace_param(
+        'The date [NOW(\'%Y-%m-%dT%H:%M:%SZ\') - 1 DAYS] was yesterday '
+        'and I have an appointment at [NOW + 10 MINUTES]', language='es')
+    offset_date = datetime.datetime.strftime(
+        datetime.datetime.utcnow() - datetime.timedelta(days=1), '%Y-%m-%dT%H:%M:%SZ')
+    offset_datetime = datetime.datetime.strftime(
+        datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%d/%m/%Y %H:%M:%S')
+    assert param == f'The date {offset_date} was yesterday and I have an appointment at {offset_datetime}'
 
 
 def test_replace_param_str_int():

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -189,8 +189,18 @@ def test_replace_param_now_not_spanish():
 
 
 def test_replace_param_now_with_format():
-    param = replace_param('[NOW(\'%Y-%m-%dT%H:%M:%SZ\')]')
+    param = replace_param('[NOW(%Y-%m-%dT%H:%M:%SZ)]')
     assert param == datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def test_not_replace_param_now_with_invalid_opening_parenthesis_in_format():
+    param = replace_param('[NOW(%Y-%m-%dT(%H:%M:%SZ)]')
+    assert param == '[NOW(%Y-%m-%dT(%H:%M:%SZ)]'
+
+
+def test_not_replace_param_now_with_invalid_closing_parenthesis_in_format():
+    param = replace_param('[NOW(%Y-%m-%dT)%H:%M:%SZ)]')
+    assert param == '[NOW(%Y-%m-%dT)%H:%M:%SZ)]'
 
 
 def test_replace_param_now_offset():
@@ -200,7 +210,7 @@ def test_replace_param_now_offset():
 
 
 def test_replace_param_now_offset_with_format():
-    param = replace_param('[NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 5 MINUTES]')
+    param = replace_param('[NOW(%Y-%m-%dT%H:%M:%SZ) + 5 MINUTES]')
     assert param == datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=5), '%Y-%m-%dT%H:%M:%SZ')
 
@@ -234,21 +244,21 @@ def test_replace_param_now_offset_and_more_not_spanish():
 
 
 def test_replace_param_now_offset_with_format_and_more():
-    param = replace_param('I will arrive at [NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 10 MINUTES] tomorrow')
+    param = replace_param('I will arrive at [NOW(%Y-%m-%dT%H:%M:%SZ) + 10 MINUTES] tomorrow')
     offset_datetime = datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y-%m-%dT%H:%M:%SZ')
     assert param == f'I will arrive at {offset_datetime} tomorrow'
 
 
 def test_replace_param_now_offset_with_format_and_more_language_is_irrelevant():
-    param = replace_param('I will arrive at [NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 10 MINUTES] tomorrow', language='ru')
+    param = replace_param('I will arrive at [NOW(%Y-%m-%dT%H:%M:%SZ) + 10 MINUTES] tomorrow', language='ru')
     offset_datetime = datetime.datetime.strftime(
         datetime.datetime.utcnow() + datetime.timedelta(minutes=10), '%Y-%m-%dT%H:%M:%SZ')
     assert param == f'I will arrive at {offset_datetime} tomorrow'
 
 
 def test_replace_param_today_offset_with_format_and_more_with_extra_spaces():
-    param = replace_param('The date [NOW(\'%Y-%m-%dT%H:%M:%SZ\')   - 1    DAYS ] was yesterday')
+    param = replace_param('The date [NOW(%Y-%m-%dT%H:%M:%SZ)   - 1    DAYS ] was yesterday')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.utcnow() - datetime.timedelta(days=1), '%Y-%m-%dT%H:%M:%SZ')
     assert param == f'The date {offset_date} was yesterday'
@@ -287,8 +297,8 @@ def test_replace_param_today_offsets_and_more():
 
 def test_replace_param_now_offsets_with_format_and_more():
     param = replace_param(
-        'The date [NOW(\'%Y-%m-%dT%H:%M:%SZ\') - 1 DAYS] was yesterday '
-        'and I have an appointment at [NOW(\'%Y-%m-%dT%H:%M:%SZ\') + 10 MINUTES]')
+        'The date [NOW(%Y-%m-%dT%H:%M:%SZ) - 1 DAYS] was yesterday '
+        'and I have an appointment at [NOW(%Y-%m-%dT%H:%M:%SZ) + 10 MINUTES]')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.utcnow() - datetime.timedelta(days=1), '%Y-%m-%dT%H:%M:%SZ')
     offset_datetime = datetime.datetime.strftime(
@@ -298,7 +308,7 @@ def test_replace_param_now_offsets_with_format_and_more():
 
 def test_replace_param_now_offsets_with_and_without_format_and_more():
     param = replace_param(
-        'The date [NOW(\'%Y-%m-%dT%H:%M:%SZ\') - 1 DAYS] was yesterday '
+        'The date [NOW(%Y-%m-%dT%H:%M:%SZ) - 1 DAYS] was yesterday '
         'and I have an appointment at [NOW + 10 MINUTES]', language='es')
     offset_date = datetime.datetime.strftime(
         datetime.datetime.utcnow() - datetime.timedelta(days=1), '%Y-%m-%dT%H:%M:%SZ')

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -66,7 +66,7 @@ def replace_param(param, language='es', infer_param_type=True):
         [TIMESTAMP] Generates a timestamp from the current time
         [DATETIME] Generates a datetime from the current time
         [NOW] Similar to DATETIME without milliseconds; the format depends on the language
-        [NOW('%Y-%m-%dT%H:%M:%SZ')] Same as NOW but using an specific format by the python strftime function of the datetime module
+        [NOW(%Y-%m-%dT%H:%M:%SZ)] Same as NOW but using an specific format by the python strftime function of the datetime module
         [NOW + 2 DAYS] Similar to NOW but two days later
         [NOW - 1 MINUTES] Similar to NOW but one minute earlier
         [TODAY] Similar to NOW without time; the format depends on the language
@@ -148,7 +148,7 @@ def _find_param_date_expressions(param):
     - expression is sorrounded by [ and ]
     - first word of the expression is either NOW or TODAY
     - when first word is NOW, it can have an addtional format for the date between parenthesis, 
-        like NOW('%Y-%m-%dT%H:%M:%SZ'). The definition of the format is the same as considered by the
+        like NOW(%Y-%m-%dT%H:%M:%SZ). The definition of the format is the same as considered by the
         python strftime function of the datetime module
     - and optional offset can be given by indicating how many days, hours, etc.. to add or remove to the current datetime.
         This part of the expression includes a +/- symbol plus a number and a unit
@@ -156,15 +156,15 @@ def _find_param_date_expressions(param):
     Some valid expressions are:
         [NOW]
         [TODAY]
-        [NOW('%Y-%m-%dT%H:%M:%SZ')]
-        [NOW('%Y-%m-%dT%H:%M:%SZ') - 180 DAYS]
-        [NOW('%H:%M:%S') + 4 MINUTES]
+        [NOW(%Y-%m-%dT%H:%M:%SZ)]
+        [NOW(%Y-%m-%dT%H:%M:%SZ) - 180 DAYS]
+        [NOW(%H:%M:%S) + 4 MINUTES]
 
     :param param: parameter value
     :param language: language to configure date format for NOW and TODAY
     :return: An array with all the matching date expressions found in the param
     """
-    return re.findall(r"\[(?:NOW(?:\('(?:[^']*)'\))?|TODAY)(?:\s*[\+|-]\s*\d+\s*\w+\s*)?\]", param)
+    return re.findall(r"\[(?:NOW(?:\((?:[^\(\)]*)\))?|TODAY)(?:\s*[\+|-]\s*\d+\s*\w+\s*)?\]", param)
 
 
 def _replace_param_replacement(param, language):
@@ -246,7 +246,7 @@ def _replace_param_date(param, language):
     :return: tuple with replaced value and boolean to know if replacement has been done
     """
     def _date_matcher():
-        return re.match(r'\[(NOW(?:\((?:\'.*\'|".*")\)|)|TODAY)(?:\s*([\+|-]\s*\d+)\s*(\w+)\s*)?\]', param)
+        return re.match(r'\[(NOW(?:\((?:.*)\)|)|TODAY)(?:\s*([\+|-]\s*\d+)\s*(\w+)\s*)?\]', param)
 
     def _offset_datetime(amount, units):
         now = datetime.datetime.utcnow()
@@ -266,7 +266,7 @@ def _replace_param_date(param, language):
         return f'{date_format} %H:%M:%S'
 
     def _get_format(base):
-        format_matcher = re.match(r'.*\'(.*)\'.*', base)    
+        format_matcher = re.match(r'.*\((.*)\).*', base)
         if format_matcher and len(format_matcher.groups()) == 1:
             return format_matcher.group(1)
         return _default_format(base)

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -69,6 +69,7 @@ def replace_param(param, language='es', infer_param_type=True):
         [NOW(%Y-%m-%dT%H:%M:%SZ)] Same as NOW but using an specific format by the python strftime function of the datetime module
         [NOW + 2 DAYS] Similar to NOW but two days later
         [NOW - 1 MINUTES] Similar to NOW but one minute earlier
+        [NOW(%Y-%m-%dT%H:%M:%SZ) - 7 DAYS] Similar to NOW but seven days before and with the indicated format
         [TODAY] Similar to NOW without time; the format depends on the language
         [TODAY + 2 DAYS] Similar to NOW, but two days later
         [STR:xxxx] Cast xxxx to a string

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -65,13 +65,11 @@ def replace_param(param, language='es', infer_param_type=True):
         [RANDOM_PHONE_NUMBER] Generates a random phone number following the pattern +34654XXXXXX
         [TIMESTAMP] Generates a timestamp from the current time
         [DATETIME] Generates a datetime from the current time
-        [DATETIME('ISO')] Same as DATETIME but using the ISO-8601 extended local date format with zulu offset
         [NOW] Similar to DATETIME without milliseconds; the format depends on the language
-        [NOW('ISO')] Same as NOW but using the ISO-8601 extended local date format with zulu offset
+        [NOW('%Y-%m-%dT%H:%M:%SZ')] Same as NOW but using an specific ISO-8601 extended local date format
         [NOW + 2 DAYS] Similar to NOW but two days later
         [NOW - 1 MINUTES] Similar to NOW but one minute earlier
         [TODAY] Similar to NOW without time; the format depends on the language
-        [TODAY('ISO')] Same as TODAY but using the ISO-8601 extended local date format with zulu offset
         [TODAY + 2 DAYS] Similar to NOW, but two days later
         [STR:xxxx] Cast xxxx to a string
         [INT:xxxx] Cast xxxx to an int


### PR DESCRIPTION
The placeholder [NOW] and the related one including offsets [NOW +/- offset] can now include a custom format. Here, some examples:
[NOW(%Y-%m-%dT%H:%M:%SZ)]
[NOW(%Y-%m-%dT%H:%M:%SZ) + 10 MINUTES]
[NOW(%Y-%m-%d) - 180 DAYS]
...