### PR TITLE
feat: search dotted keys into context storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ v2.6.1
 
 *Release date: In development*
 
+- Reference dotted keys when saving objects in context storage using [CONTEXT:a.b.c] formula
+
 v2.6.0
 ------
 

--- a/toolium/test/utils/test_dataset_map_param.py
+++ b/toolium/test/utils/test_dataset_map_param.py
@@ -108,6 +108,42 @@ def test_a_context_param():
     assert expected_st == result_st
 
 
+def test_a_context_param_with_dots():
+    """
+    Verification of a mapped parameter with dots as CONTEXT
+    """
+    context = mock.MagicMock()
+    class Obj(object):
+        pass
+    one = Obj()
+    one.two = "the value"
+
+    context.one = one
+    dataset.behave_context = context
+
+    result_att = map_param("[CONTEXT:one.two]")
+    expected_att = "the value"
+    assert expected_att == result_att
+
+
+def test_a_context_param_with_dots_in_storage():
+    """
+    Verification of a mapped parameter with dots into the storage as CONTEXT
+    """
+    context = mock.MagicMock()
+    class Obj(object):
+        pass
+    one = Obj()
+    one.two = "the value"
+
+    context.storage = {"one": one}
+    dataset.behave_context = context
+
+    result_att = map_param("[CONTEXT:one.two]")
+    expected_att = "the value"
+    assert expected_att == result_att
+
+
 def test_a_context_param_deprecated():
     """
     Verification of a mapped parameter as CONTEXT and check that deprecated message is logged

--- a/toolium/test/utils/test_dataset_map_param.py
+++ b/toolium/test/utils/test_dataset_map_param.py
@@ -113,10 +113,9 @@ def test_a_context_param_with_dots():
     Verification of a mapped parameter with dots as CONTEXT
     """
     context = mock.MagicMock()
-    
+
     class Obj(object):
         pass
-
     one = Obj()
     one.two = "the value"
 
@@ -133,10 +132,9 @@ def test_a_context_param_with_dots_in_storage():
     Verification of a mapped parameter with dots into the storage as CONTEXT
     """
     context = mock.MagicMock()
-    
+
     class Obj(object):
         pass
-
     one = Obj()
     one.two = "the value"
 

--- a/toolium/test/utils/test_dataset_map_param.py
+++ b/toolium/test/utils/test_dataset_map_param.py
@@ -126,23 +126,14 @@ def test_a_context_param_with_dots():
     expected_att = "the value"
     assert expected_att == result_att
 
+    three = Obj()
+    three.four = "the other value"
 
-def test_a_context_param_with_dots_in_storage():
-    """
-    Verification of a mapped parameter with dots into the storage as CONTEXT
-    """
-    context = mock.MagicMock()
-
-    class Obj(object):
-        pass
-    one = Obj()
-    one.two = "the value"
-
-    context.storage = {"one": one}
+    context.storage = {"three": three}
     dataset.behave_context = context
 
-    result_att = map_param("[CONTEXT:one.two]")
-    expected_att = "the value"
+    result_att = map_param("[CONTEXT:three.four]")
+    expected_att = "the other value"
     assert expected_att == result_att
 
 

--- a/toolium/test/utils/test_dataset_map_param.py
+++ b/toolium/test/utils/test_dataset_map_param.py
@@ -115,6 +115,7 @@ def test_a_context_param_with_dots():
     context = mock.MagicMock()
     class Obj(object):
         pass
+
     one = Obj()
     one.two = "the value"
 
@@ -133,6 +134,7 @@ def test_a_context_param_with_dots_in_storage():
     context = mock.MagicMock()
     class Obj(object):
         pass
+
     one = Obj()
     one.two = "the value"
 

--- a/toolium/test/utils/test_dataset_map_param.py
+++ b/toolium/test/utils/test_dataset_map_param.py
@@ -113,6 +113,7 @@ def test_a_context_param_with_dots():
     Verification of a mapped parameter with dots as CONTEXT
     """
     context = mock.MagicMock()
+    
     class Obj(object):
         pass
 
@@ -132,6 +133,7 @@ def test_a_context_param_with_dots_in_storage():
     Verification of a mapped parameter with dots into the storage as CONTEXT
     """
     context = mock.MagicMock()
+    
     class Obj(object):
         pass
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -577,26 +577,48 @@ def map_toolium_param(param, config):
 def get_value_from_context(param, context):
     """
     Find the value of the given param using it as a key in the context storage dictionary (context.storage) or in the
-    context object itself. So for example, in the former case, "last_request_result" could be used to retrieve the value
-    from context.storage["last_request_result"], if it exists, whereas, in the latter case, "last_request.result" could
-    be used to retrieve the value from context.last_request.result, if it exists.
+    context object itself. The key might be comprissed of dotted tokens. In such case, the searched key is the first
+    token. The rest of the tokens are considered nested properties/objects.
+    So, for example, in the basic case, "last_request_result" could be used as key that would be searched into context
+    storage or the context object itself. In a dotted case, "last_request.result" is searched as a "last_request" key
+    in the context storage or as a property of the context object whose name is last_request. In both cases, when found,
+    "result" is considered (and resolved) as a property into the returned value. There is not limit in the nested
+    levels of dotted tokens.
+
+    a key like a.b.c.d is considered like this:
+
+    context.storage['a'].b.c.d
+        or
+    context.a.b.c.d
 
     :param param: key to be searched (e.g. "last_request_result" / "last_request.result")
     :param context: Behave context object
     :return: mapped value
     """
-    if context.storage and param in context.storage:
-        return context.storage[param]
-    logger.info(f"'{param}' key not found in context storage, searching in context")
-    try:
-        value = context
-        for part in param.split('.'):
-            value = getattr(value, part)
-        return value
-    except AttributeError:
-        msg = f"'{param}' not found neither in context storage nor in context"
-        logger.error(msg)
-        raise AttributeError(msg)
+    parts = param.split('.')
+    value = None
+    if context.storage and parts[0] in context.storage:
+        value = context.storage[parts[0]]
+    else:
+        logger.info(f"'{parts[0]}' key not found in context storage, searching in context")
+        try:
+            value = getattr(context, parts[0])
+        except AttributeError:
+            msg = f"'{parts[0]}' not found neither in context storage nor in context"
+            logger.error(msg)
+            raise AttributeError(msg)
+
+    if len(parts) > 1:
+        try:
+            for part in parts[1:]:
+                value = getattr(value, part)
+        except AttributeError:
+            msg = f"'{part}' is not an attribute of {value}"
+            logger.error(msg)
+            raise AttributeError(msg)
+
+    return value
+
 
 
 def get_message_property(param, language_terms, language_key):


### PR DESCRIPTION
the [CONTEXT:blablabla] does not accept dotted keys if the
element is into the context storage intead of as part of the
context itself. This commit permits searching either in the
context or in the storage by resolving as
context.storage['a'].b.c for a [CONTEXT:a.b.c] key