### PR TITLE
fix: ensure close_drivers method is always called in after feature hook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v2.7.0
 
 *Release date: In development*
 
+- Fix drivers not being closed in `after_feature` when errors occur during `before_feature` steps execution
 - Allow to add extensions to chrome options from properties file
 
    New config section [ChromeExtensions] with extensions file paths, e.g. 'firebug: resources/firebug-lite.crx'

--- a/toolium/behave/environment.py
+++ b/toolium/behave/environment.py
@@ -276,12 +276,13 @@ def after_feature(context, feature):
     :param context: behave context
     :param feature: running feature
     """
-    # Behave dynamic environment
-    context.dyn_env.execute_after_feature_steps(context)
-
-    # Close drivers
-    DriverWrappersPool.close_drivers(scope='module', test_name=feature.name,
-                                     test_passed=context.global_status['test_passed'])
+    try:
+        # Behave dynamic environment
+        context.dyn_env.execute_after_feature_steps(context)
+    finally:
+        # Close drivers regardless of an Exception being raised due to failed preconditions
+        DriverWrappersPool.close_drivers(scope='module', test_name=feature.name,
+                                         test_passed=context.global_status['test_passed'])
 
 
 def after_all(context):

--- a/toolium/test/behave/test_environment.py
+++ b/toolium/test/behave/test_environment.py
@@ -266,6 +266,25 @@ def test_after_feature(DriverWrappersPool):
 
 
 @mock.patch('toolium.behave.environment.DriverWrappersPool')
+def test_after_feature_with_failed_preconditions(DriverWrappersPool):
+    # Create context mock
+    context = mock.MagicMock()
+    context.global_status = {'test_passed': True}
+    feature = mock.MagicMock()
+    feature.name = 'name'
+    context.dyn_env = mock.MagicMock()
+    context.dyn_env.execute_after_feature_steps.side_effect = Exception('Preconditions failed')
+
+    try:
+        after_feature(context, feature)
+    except Exception:
+        pass
+
+    # Check that close_drivers is called
+    DriverWrappersPool.close_drivers.assert_called_once_with(scope='module', test_name='name', test_passed=True)
+
+
+@mock.patch('toolium.behave.environment.DriverWrappersPool')
 def test_after_all(DriverWrappersPool):
     # Create context mock
     context = mock.MagicMock()


### PR DESCRIPTION
Ensure the close_drivers method in after_feature is always called. That was not happening when there had been a failure executing the preconditions, due to the exception that is raised in that case.