### PR TITLE
Fix: Only AppiumCapabilities are taken into account in mobile execution

### DIFF
--- a/toolium/config_driver.py
+++ b/toolium/config_driver.py
@@ -109,6 +109,7 @@ class ConfigDriver(object):
             # Get driver options
             options = AppiumOptions()
             self._add_capabilities_from_properties(capabilities, 'AppiumCapabilities')
+            self._add_capabilities_from_properties(capabilities, 'Capabilities')
             self._update_dict(options.capabilities, capabilities)
 
             # Create remote appium driver


### PR DESCRIPTION
<h2> Why </h2>

platformName is a standard selenium capability and not an appium one. Until now there wasn't any problem but now, Appium Devices Farm plugin is treating this in a more strictly way and the following error was returned:

```
 [device-farm] The capabilities ["platformName"] are standard capabilities and do not require "appium:" prefix{
  'appium:autoGrantPermissions': true,
  'appium:bigQueryDeviceName': '',
  'appium:language': 'es',
  'appium:locale': 'ES',
  'appium:newCommandTimeout': 650,
  'appium:processArguments': { args: [ '-FIRAnalyticsDebugEnabled', '-FIRDebugEnabled' ] },
  'appium:resetKeyboard': true,
  'appium:adbExecTimeout': 50000,
  'appium:automationName': 'UiAutomator2',
  'appium:platformName': 'Android',
  'appium:platformVersion': '',
  'appium:udid': '',
  'appium:unicodeKeyboard': true,
  'appium:appWaitDuration': 40000,
  'appium:appActivity': 'com.movistar.base.ui.splash.SplashActivity',
  'appium:appPackage': 'com.movistar.base.debug',
  'appium:app': '/tmp/Android-Enterprise-ES_1687478976.apk'
}
[AppiumDriver@887b] Command 'createSession' was *not* handled by the following behaviours or plugins, even though they were registered to handle it: ["default","appium-dashboard"]. The command *was* handled by these: ["device-farm"].
[debug] [AppiumDriver@887b] Encountered internal error running command: TypeError: Cannot read properties of undefined (reading 'toLowerCase')
[debug] [AppiumDriver@887b]     at getDeviceFiltersFromCapability (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/device-utils.js:200:49)
[debug] [AppiumDriver@887b]     at /Users/cx02592/.appium/node_modules/appium-device-farm/lib/device-utils.js:92:25
[debug] [AppiumDriver@887b]     at Generator.next (<anonymous>)
[debug] [AppiumDriver@887b]     at /Users/cx02592/.appium/node_modules/appium-device-farm/lib/device-utils.js:8:71
[debug] [AppiumDriver@887b]     at new Promise (<anonymous>)
[debug] [AppiumDriver@887b]     at __awaiter (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/device-utils.js:4:12)
[debug] [AppiumDriver@887b]     at allocateDeviceForSession (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/device-utils.js:89:12)
[debug] [AppiumDriver@887b]     at DevicePlugin.<anonymous> (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/plugin.js:139:78)
[debug] [AppiumDriver@887b]     at Generator.next (<anonymous>)
[debug] [AppiumDriver@887b]     at /Users/cx02592/.appium/node_modules/appium-device-farm/lib/plugin.js:8:71
[debug] [AppiumDriver@887b]     at new Promise (<anonymous>)
[debug] [AppiumDriver@887b]     at __awaiter (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/plugin.js:4:12)
[debug] [AppiumDriver@887b]     at /Users/cx02592/.appium/node_modules/appium-device-farm/lib/plugin.js:136:93
[debug] [AppiumDriver@887b]     at /Users/cx02592/.appium/node_modules/async-lock/lib/index.js:171:12
[debug] [AppiumDriver@887b]     at AsyncLock._promiseTry (/Users/cx02592/.appium/node_modules/async-lock/lib/index.js:304:31)
[debug] [AppiumDriver@887b]     at exec (/Users/cx02592/.appium/node_modules/async-lock/lib/index.js:170:9)
[debug] [AppiumDriver@887b]     at AsyncLock.acquire (/Users/cx02592/.appium/node_modules/async-lock/lib/index.js:187:3)
[debug] [AppiumDriver@887b]     at DevicePlugin.<anonymous> (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/plugin.js:136:53)
[debug] [AppiumDriver@887b]     at Generator.next (<anonymous>)
[debug] [AppiumDriver@887b]     at fulfilled (/Users/cx02592/.appium/node_modules/appium-device-farm/lib/plugin.js:5:58)
[debug] [AppiumDriver@887b]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[HTTP] <-- POST /wd/hub/session 500 15 
```

This error was thrown due this line:

```
const platform = capability['platformName'].toLowerCase();
```

As you could see, platformName is not processed as an appium capability like platformVersion:

```
 platformVersion: capability['appium:platformVersion']
            ? capability['appium:platformVersion']
            : undefined,
        name,

```

<h2> Change </h2>

We agreed to use Capabilities in addition to AppiumCapabilities for mobile executions so, in this way, those who doesn't have this problem won't have any impact. 


<h2> Success proof </h2>

``` 
[BaseDriver] Ignoring capability 'appium:platformName=Android' and using capability 'platformName=Android' ---------> CHECK THIS LINE
[BaseDriver] The capabilities ["platformName"] are standard capabilities and do not require "appium:" prefix
[Appium] Attempting to find matching driver for automationName 'UiAutomator2' and platformName 'Android'
[Appium] The 'uiautomator2' driver was installed and matched caps.
[Appium] Will require it at /Users/cx02592/.appium/node_modules/appium-uiautomator2-driver
[debug] [Appium] Requiring driver at /Users/cx02592/.appium/node_modules/appium-uiautomator2-driver
[AppiumDriver@f3b4] Appium v2.0.0-rc.3 creating new AndroidUiautomator2Driver (v2.27.0) session
[AppiumDriver@f3b4] Checking BaseDriver versions for Appium and AndroidUiautomator2Driver
[AppiumDriver@f3b4] Appium's BaseDriver version is 9.3.13
[AppiumDriver@f3b4] AndroidUiautomator2Driver's BaseDriver version is 9.3.13
[debug] [AndroidUiautomator2Driver@6398] Creating session with W3C capabilities: {
[debug] [AndroidUiautomator2Driver@6398]   "alwaysMatch": {
[debug] [AndroidUiautomator2Driver@6398]     "platformName": "Android",  ---------> CHECK THIS LINE
[debug] [AndroidUiautomator2Driver@6398]     "appium:autoGrantPermissions": true,
[debug] [AndroidUiautomator2Driver@6398]     "appium:bigQueryDeviceName": "",
[debug] [AndroidUiautomator2Driver@6398]     "appium:language": "es",
[debug] [AndroidUiautomator2Driver@6398]     "appium:locale": "ES",
[debug] [AndroidUiautomator2Driver@6398]     "appium:newCommandTimeout": 650,
[debug] [AndroidUiautomator2Driver@6398]     "appium:processArguments": {
[debug] [AndroidUiautomator2Driver@6398]       "args": [
[debug] [AndroidUiautomator2Driver@6398]         "-FIRAnalyticsDebugEnabled",
[debug] [AndroidUiautomator2Driver@6398]         "-FIRDebugEnabled"
[debug] [AndroidUiautomator2Driver@6398]       ]
[debug] [AndroidUiautomator2Driver@6398]     },
[debug] [AndroidUiautomator2Driver@6398]     "appium:resetKeyboard": true,
[debug] [AndroidUiautomator2Driver@6398]     "appium:adbExecTimeout": 50000,
[debug] [AndroidUiautomator2Driver@6398]     "appium:automationName": "UiAutomator2",
[debug] [AndroidUiautomator2Driver@6398]     "appium:platformVersion": "",
[debug] [AndroidUiautomator2Driver@6398]     "appium:unicodeKeyboard": true,
[debug] [AndroidUiautomator2Driver@6398]     "appium:appWaitDuration": 40000,
[debug] [AndroidUiautomator2Driver@6398]     "appium:appActivity": "com.movistar.base.ui.splash.SplashActivity",
[debug] [AndroidUiautomator2Driver@6398]     "appium:appPackage": "com.movistar.base.debug",
[debug] [AndroidUiautomator2Driver@6398]     "appium:app": "/tmp/Android-Enterprise-ES_1687738114.apk",
[debug] [AndroidUiautomator2Driver@6398]     "appium:clearDeviceLogsOnStart": true,
[debug] [AndroidUiautomator2Driver@6398]     "appium:nativeWebScreenshot": true,
[debug] [AndroidUiautomator2Driver@6398]     "appium:udid": "9c23caaa0506",
[debug] [AndroidUiautomator2Driver@6398]     "appium:systemPort": 60974,
[debug] [AndroidUiautomator2Driver@6398]     "appium:chromeDriverPort": 60975,
[debug] [AndroidUiautomator2Driver@6398]     "appium:adbPort": 5037,
[debug] [AndroidUiautomator2Driver@6398]     "appium:mjpegServerPort": 60976
[debug] [AndroidUiautomator2Driver@6398]   },
[debug] [AndroidUiautomator2Driver@6398]   "firstMatch": [
[debug] [AndroidUiautomator2Driver@6398]     {}
[debug] [AndroidUiautomator2Driver@6398]   ]
[debug] [AndroidUiautomator2Driver@6398] }

```