### PR TITLE
NOV-238610: update android automatic context selection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ v3.1.0
 - `platformVersion` Appium capability must be a string
 - Add optional parameter to `compare_downloaded_files` method to allow to compare files with different names
 - Remove Python 3.7 support (Python 3.7 reached the end of its life on June 27th, 2023)
+- Update _android_automatic_context_selection method to be compatible with latest chromedriver versions
 
 v3.0.2
 ------

--- a/toolium/pageelements/page_element.py
+++ b/toolium/pageelements/page_element.py
@@ -130,13 +130,14 @@ class PageElement(CommonObject):
             else:
                 app_web_context = "{}_{}".format(PageElement.webview_context_prefix,
                                                  self.driver.capabilities['appPackage'])
-                contexts = self.driver.execute_script('mobile: getContexts')
-                context_dict = next(
-                    (item for item in contexts if 'webviewName' in item and item['webviewName'] == app_web_context),
-                    None)
-                if context_dict and 'pages' in context_dict:
+                if app_web_context in self.driver.contexts:
                     context = app_web_context
-                    window_handle = 'CDwindow-{}'.format(context_dict['pages'][0]['id'])
+                    if self.driver.context != context:
+                        self.driver.switch_to.context(context)
+                    window_handle = self.driver.window_handles[0]
+                else:
+                    raise KeyError("WEBVIEW context not found")
+
             if context:
                 if self.driver.context != context:
                     self.driver.switch_to.context(context)

--- a/toolium/test/pageelements/test_page_element.py
+++ b/toolium/test/pageelements/test_page_element.py
@@ -457,10 +457,9 @@ def test_android_automatic_context_selection_already_in_desired_webview_context_
     driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.capabilities = {'appPackage': 'test.package.fake'}
     driver_wrapper.driver.context = "WEBVIEW_test.package.fake"
-    driver_wrapper.driver.current_window_handle = "CWindow-1234567890"
-    driver_wrapper.driver.execute_script.return_value = [{'webviewName': 'WEBVIEW_test.package.fake',
-                                                          'pages': [{'id': '1234567890'},
-                                                                    {'id': '0987654321'}]}]
+    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW_test.package.fake"]
+    driver_wrapper.driver.current_window_handle = "1234567890"
+    driver_wrapper.driver.window_handles = ['1234567890']
     RegisterPageObject(driver_wrapper).element_webview.web_element
     driver_wrapper.driver.switch_to.context.assert_not_called
     driver_wrapper.driver.switch_to.window.assert_not_called
@@ -473,13 +472,12 @@ def test_android_automatic_context_selection_already_in_desired_webview_context_
     driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.capabilities = {'appPackage': 'test.package.fake'}
     driver_wrapper.driver.context = "WEBVIEW_test.package.fake"
-    driver_wrapper.driver.current_window_handle = "CDwindow-0987654321"
-    driver_wrapper.driver.execute_script.return_value = [{'webviewName': 'WEBVIEW_test.package.fake',
-                                                          'pages': [{'id': '1234567890'},
-                                                                    {'id': '0987654321'}]}]
+    driver_wrapper.driver.contexts = ["NATIVE_APP", "WEBVIEW_test.package.fake"]
+    driver_wrapper.driver.current_window_handle = "0987654321"
+    driver_wrapper.driver.window_handles = ["1234567890", "0987654321"]
     RegisterPageObject(driver_wrapper).element_webview.web_element
     driver_wrapper.driver.switch_to.context.assert_not_called
-    driver_wrapper.driver.switch_to.window.assert_called_once_with('CDwindow-1234567890')
+    driver_wrapper.driver.switch_to.window.assert_called_once_with('1234567890')
 
 
 def test_ios_automatic_context_selection_already_in_desired_webview_context(driver_wrapper):
@@ -506,13 +504,12 @@ def test_android_automatic_context_selection_switch_to_new_webview_context(drive
     driver_wrapper.config.set('Driver', 'automatic_context_selection', 'true')
     driver_wrapper.driver.capabilities = {'appPackage': 'test.package.fake'}
     driver_wrapper.driver.context = "WEBVIEW_other.fake.context"
-    driver_wrapper.driver.current_window_handle = "CDwindow-0987654321"
-    driver_wrapper.driver.execute_script.return_value = [{'webviewName': 'WEBVIEW_test.package.fake',
-                                                          'pages': [{'id': '1234567890'},
-                                                                    {'id': '0987654321'}]}]
+    driver_wrapper.driver.contexts = ["WEBVIEW_test.package.fake", "WEBVIEW_other.fake.context"]
+    driver_wrapper.driver.current_window_handle = "0987654321"
+    driver_wrapper.driver.window_handles = ["1234567890", "0987654321"]
     RegisterPageObject(driver_wrapper).element_webview.web_element
-    driver_wrapper.driver.switch_to.context.assert_called_once_with('WEBVIEW_test.package.fake')
-    driver_wrapper.driver.switch_to.window.assert_called_once_with('CDwindow-1234567890')
+    driver_wrapper.driver.switch_to.context.assert_called_with('WEBVIEW_test.package.fake')
+    driver_wrapper.driver.switch_to.window.assert_called_once_with('1234567890')
 
 
 def test_ios_automatic_context_selection_switch_to_new_webview_context(driver_wrapper):


### PR DESCRIPTION
Chromedriver has changed in last versions (from v105), and now windows can not be identified using getContexts method, so automatic context selection for Android has been updated. This change is backward compatible

More info in Appium thread: https://github.com/appium/appium/issues/18906