### PR TITLE
NOV-244340: expression for selecting in an array for a context storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v3.1.5
 *Release date: In development*
 
 - Fix `export_poeditor_project` method allowing empty export response
+- Add key=value expressions for selecting elements in the context storage
 
 v3.1.4
 ------

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -329,7 +329,7 @@ def test_a_context_param_list_default_no_index():
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.text]")
-    assert "the element 'text' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
+    assert "the expression 'text' was not able to select an element in the list" == str(excinfo.value)
 
 
 def test_a_context_param_list_correct_index():
@@ -411,11 +411,11 @@ def test_a_context_param_list_no_numeric_index():
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.prueba.id]")
-    assert "the element 'prueba' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
+    assert "the expression 'prueba' was not able to select an element in the list" == str(excinfo.value)
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.'36'.id]")
-    assert "the element ''36'' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
+    assert "the expression ''36'' was not able to select an element in the list" == str(excinfo.value)
 
 
 def test_a_context_param_class_no_numeric_index():
@@ -441,8 +441,176 @@ def test_a_context_param_class_no_numeric_index():
     print(context)
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.prueba.id]")
-    assert "the element 'prueba' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
+    assert "the expression 'prueba' was not able to select an element in the list" == str(excinfo.value)
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.'36'.id]")
-    assert "the element ''36'' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
+    assert "the expression ''36'' was not able to select an element in the list" == str(excinfo.value)
+
+
+def test_a_context_param_list_correct_select_expression():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param("[CONTEXT:list.cmsScrollableActions.id=ask-for-qa.text]") == 'QA no duplica'
+
+
+def test_a_context_param_list_correct_select_expression_with_value_single_quotes():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param("[CONTEXT:list.cmsScrollableActions.id='ask-for-qa'.text]") == 'QA no duplica'
+
+
+def test_a_context_param_list_correct_select_expression_with_value_double_quotes():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param('[CONTEXT:list.cmsScrollableActions.id="ask-for-qa".text]') == 'QA no duplica'
+
+
+def test_a_context_param_list_correct_select_expression_with_key_single_quotes():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param("[CONTEXT:list.cmsScrollableActions.'id'=ask-for-qa.text]") == 'QA no duplica'
+
+
+def test_a_context_param_list_correct_select_expression_with_key_double_quotes():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param('[CONTEXT:list.cmsScrollableActions."id"=ask-for-qa.text]') == 'QA no duplica'
+
+
+def test_a_context_param_list_correct_select_expression_with_key_and_value_with_quotes():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param('[CONTEXT:list.cmsScrollableActions."id"="ask-for-qa".text]') == 'QA no duplica'
+
+
+def test_a_context_param_list_correct_select_expression_with_blanks():
+    """
+    Verification of a list with a correct select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param('[CONTEXT:list.cmsScrollableActions.text="QA no duplica".id]') == 'ask-for-qa'

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -452,294 +452,278 @@ def test_a_context_param_list_correct_select_expression():
     """
     Verification of a list with a correct select expression as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param("[CONTEXT:list.cmsScrollableActions.id=ask-for-qa.text]") == 'QA no duplica'
+    assert (
+        map_param("[CONTEXT:list.cmsScrollableActions.id=ask-for-qa.text]")
+        == "QA no duplica"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_value_single_quotes():
     """
     Verification of a list with a correct select expression having single quotes for value as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param("[CONTEXT:list.cmsScrollableActions.id='ask-for-qa'.text]") == 'QA no duplica'
+    assert (
+        map_param("[CONTEXT:list.cmsScrollableActions.id='ask-for-qa'.text]")
+        == "QA no duplica"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_value_double_quotes():
     """
     Verification of a list with a correct select expression having double quotes for value as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param('[CONTEXT:list.cmsScrollableActions.id="ask-for-qa".text]') == 'QA no duplica'
+    assert (
+        map_param('[CONTEXT:list.cmsScrollableActions.id="ask-for-qa".text]')
+        == "QA no duplica"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_key_single_quotes():
     """
     Verification of a list with a correct select expression having single quotes for the value as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param("[CONTEXT:list.cmsScrollableActions.'id'=ask-for-qa.text]") == 'QA no duplica'
+    assert (
+        map_param("[CONTEXT:list.cmsScrollableActions.'id'=ask-for-qa.text]")
+        == "QA no duplica"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_key_double_quotes():
     """
     Verification of a list with a correct select expression having double quotes for the key as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param('[CONTEXT:list.cmsScrollableActions."id"=ask-for-qa.text]') == 'QA no duplica'
+    assert (
+        map_param('[CONTEXT:list.cmsScrollableActions."id"=ask-for-qa.text]')
+        == "QA no duplica"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_key_and_value_with_quotes():
     """
     Verification of a list with a correct select expression having quotes for both key and value as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param('[CONTEXT:list.cmsScrollableActions."id"="ask-for-qa".text]') == 'QA no duplica'
+    assert (
+        map_param('[CONTEXT:list.cmsScrollableActions."id"="ask-for-qa".text]')
+        == "QA no duplica"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_blanks():
     """
     Verification of a list with a correct select expression with blanks in the text to search for as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param('[CONTEXT:list.cmsScrollableActions.text="QA no duplica".id]') == 'ask-for-qa'
+    assert (
+        map_param('[CONTEXT:list.cmsScrollableActions.text="QA no duplica".id]')
+        == "ask-for-qa"
+    )
 
 
 def test_a_context_param_list_correct_select_expression_finds_nothing():
     """
     Verification of a list with a correct select expression which obtains no result as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.id='not-existing-id'.text]")
-    assert "the expression 'id='not-existing-id'' was not able to select an element in the list" == str(excinfo.value)
+    assert (
+        "the expression 'id='not-existing-id'' was not able to select an element in the list"
+        == str(excinfo.value)
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_empty_value_finds_nothing():
     """
     Verification of a list with a correct select expression with empty value which obtains no result as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.id=''.text]")
-    assert "the expression 'id=''' was not able to select an element in the list" == str(excinfo.value)
+    assert (
+        "the expression 'id=''' was not able to select an element in the list"
+        == str(excinfo.value)
+    )
 
 
 def test_a_context_param_list_correct_select_expression_with_empty_value_hits_value():
     """
     Verification of a list with a correct select expression with empty value which obtains no result as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': '',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
-    assert map_param("[CONTEXT:list.cmsScrollableActions.id=''.text]") == 'QA duplica'
+    assert map_param("[CONTEXT:list.cmsScrollableActions.id=''.text]") == "QA duplica"
 
 
 def test_a_context_param_list_invalid_select_expression():
     """
     Verification of a list with an invalid select expression as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.invalidexpression.text]")
-    assert "the expression 'invalidexpression' was not able to select an element in the list" == str(excinfo.value)
+    assert (
+        "the expression 'invalidexpression' was not able to select an element in the list"
+        == str(excinfo.value)
+    )
 
 
 def test_a_context_param_list_invalid_select_expression_having_empty_key():
     """
     Verification of a list with a invalid select expression having empty key as CONTEXT
     """
+
     class Context(object):
         pass
+
     context = Context()
 
     context.list = {
-        'cmsScrollableActions': [
-            {
-                'id': 'ask-for-duplicate',
-                'text': 'QA duplica'
-            },
-            {
-                'id': 'ask-for-qa',
-                'text': 'QA no duplica'
-            }
+        "cmsScrollableActions": [
+            {"id": "ask-for-duplicate", "text": "QA duplica"},
+            {"id": "ask-for-qa", "text": "QA no duplica"},
         ]
     }
     dataset.behave_context = context
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.='not-existing-id'.text]")
-    assert "the expression '='not-existing-id'' was not able to select an element in the list" == str(excinfo.value)
-
+    assert (
+        "the expression '='not-existing-id'' was not able to select an element in the list"
+        == str(excinfo.value)
+    )

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -329,7 +329,7 @@ def test_a_context_param_list_default_no_index():
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.text]")
-    assert "the index 'text' must be a numeric index" == str(excinfo.value)
+    assert "the element 'text' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
 
 
 def test_a_context_param_list_correct_index():
@@ -411,11 +411,11 @@ def test_a_context_param_list_no_numeric_index():
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.prueba.id]")
-    assert "the index 'prueba' must be a numeric index" == str(excinfo.value)
+    assert "the element 'prueba' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.'36'.id]")
-    assert "the index ''36'' must be a numeric index" == str(excinfo.value)
+    assert "the element ''36'' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
 
 
 def test_a_context_param_class_no_numeric_index():
@@ -441,8 +441,8 @@ def test_a_context_param_class_no_numeric_index():
     print(context)
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.prueba.id]")
-    assert "the index 'prueba' must be a numeric index" == str(excinfo.value)
+    assert "the element 'prueba' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)
 
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.'36'.id]")
-    assert "the index ''36'' must be a numeric index" == str(excinfo.value)
+    assert "the element ''36'' must be a numeric index or a valid key=value expression to select an element in a list" == str(excinfo.value)

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -474,7 +474,7 @@ def test_a_context_param_list_correct_select_expression():
 
 def test_a_context_param_list_correct_select_expression_with_value_single_quotes():
     """
-    Verification of a list with a correct select expression as CONTEXT
+    Verification of a list with a correct select expression having single quotes for value as CONTEXT
     """
     class Context(object):
         pass
@@ -498,7 +498,7 @@ def test_a_context_param_list_correct_select_expression_with_value_single_quotes
 
 def test_a_context_param_list_correct_select_expression_with_value_double_quotes():
     """
-    Verification of a list with a correct select expression as CONTEXT
+    Verification of a list with a correct select expression having double quotes for value as CONTEXT
     """
     class Context(object):
         pass
@@ -522,7 +522,7 @@ def test_a_context_param_list_correct_select_expression_with_value_double_quotes
 
 def test_a_context_param_list_correct_select_expression_with_key_single_quotes():
     """
-    Verification of a list with a correct select expression as CONTEXT
+    Verification of a list with a correct select expression having single quotes for the value as CONTEXT
     """
     class Context(object):
         pass
@@ -546,7 +546,7 @@ def test_a_context_param_list_correct_select_expression_with_key_single_quotes()
 
 def test_a_context_param_list_correct_select_expression_with_key_double_quotes():
     """
-    Verification of a list with a correct select expression as CONTEXT
+    Verification of a list with a correct select expression having double quotes for the key as CONTEXT
     """
     class Context(object):
         pass
@@ -570,7 +570,7 @@ def test_a_context_param_list_correct_select_expression_with_key_double_quotes()
 
 def test_a_context_param_list_correct_select_expression_with_key_and_value_with_quotes():
     """
-    Verification of a list with a correct select expression as CONTEXT
+    Verification of a list with a correct select expression having quotes for both key and value as CONTEXT
     """
     class Context(object):
         pass
@@ -594,7 +594,7 @@ def test_a_context_param_list_correct_select_expression_with_key_and_value_with_
 
 def test_a_context_param_list_correct_select_expression_with_blanks():
     """
-    Verification of a list with a correct select expression as CONTEXT
+    Verification of a list with a correct select expression with blanks in the text to search for as CONTEXT
     """
     class Context(object):
         pass
@@ -614,3 +614,132 @@ def test_a_context_param_list_correct_select_expression_with_blanks():
     }
     dataset.behave_context = context
     assert map_param('[CONTEXT:list.cmsScrollableActions.text="QA no duplica".id]') == 'ask-for-qa'
+
+
+def test_a_context_param_list_correct_select_expression_finds_nothing():
+    """
+    Verification of a list with a correct select expression which obtains no result as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    with pytest.raises(Exception) as excinfo:
+        map_param("[CONTEXT:list.cmsScrollableActions.id='not-existing-id'.text]")
+    assert "the expression 'id='not-existing-id'' was not able to select an element in the list" == str(excinfo.value)
+
+
+def test_a_context_param_list_correct_select_expression_with_empty_value_finds_nothing():
+    """
+    Verification of a list with a correct select expression with empty value which obtains no result as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    with pytest.raises(Exception) as excinfo:
+        map_param("[CONTEXT:list.cmsScrollableActions.id=''.text]")
+    assert "the expression 'id=''' was not able to select an element in the list" == str(excinfo.value)
+
+
+def test_a_context_param_list_correct_select_expression_with_empty_value_hits_value():
+    """
+    Verification of a list with a correct select expression with empty value which obtains no result as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': '',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param("[CONTEXT:list.cmsScrollableActions.id=''.text]") == 'QA duplica'
+
+
+def test_a_context_param_list_invalid_select_expression():
+    """
+    Verification of a list with an invalid select expression as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    with pytest.raises(Exception) as excinfo:
+        map_param("[CONTEXT:list.cmsScrollableActions.invalidexpression.text]")
+    assert "the expression 'invalidexpression' was not able to select an element in the list" == str(excinfo.value)
+
+
+def test_a_context_param_list_invalid_select_expression_having_empty_key():
+    """
+    Verification of a list with a invalid select expression having empty key as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    with pytest.raises(Exception) as excinfo:
+        map_param("[CONTEXT:list.cmsScrollableActions.='not-existing-id'.text]")
+    assert "the expression '='not-existing-id'' was not able to select an element in the list" == str(excinfo.value)
+

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -727,3 +727,25 @@ def test_a_context_param_list_invalid_select_expression_having_empty_key():
         "the expression '='not-existing-id'' was not able to select an element in the list"
         == str(excinfo.value)
     )
+
+
+def test_a_context_param_list_invalid_structure_for_valid_select():
+    """
+    Verification of a list with a invalid structure for a valid select as CONTEXT
+    """
+
+    class Context(object):
+        pass
+
+    context = Context()
+
+    context.list = {
+        "cmsScrollableActions": {"id": "ask-for-duplicate", "text": "QA duplica"},
+    }
+    dataset.behave_context = context
+    with pytest.raises(Exception) as excinfo:
+        map_param("[CONTEXT:list.cmsScrollableActions.id=ask-for-duplicate.text]")
+    assert (
+        "'id=ask-for-duplicate' key not found in {'id': 'ask-for-duplicate', 'text': 'QA duplica'} value in context"
+        == str(excinfo.value)
+    )

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -578,8 +578,19 @@ def get_value_from_context(param, context):
     storages or the context object itself. In a dotted case, "last_request.result" is searched as a "last_request" key
     in the context storages or as a property of the context object whose name is last_request. In both cases, when
     found, "result" is considered (and resolved) as a property or a key into the returned value.
+
     If the resolved element at one of the tokens is a list, then the next token (if present) is used as the index
-    to select one of its elements, e.g. "list.1" returns the second element of the list "list".
+    to select one of its elements in case it is a number, e.g. "list.1" returns the second element of the list "list".
+
+    If the resolved element at one of the tokens is a list and the next token is a key=value expression, then the
+    element in the list that matches the key=value expression is selected, e.g. "list.key=value" returns the element
+    in the list "list" that has the value for key attribute. So, for example, if the list is:
+    [
+        {"key": "value1", "attr": "attr1"},
+        {"key": "value2", "attr": "attr2"}
+    ]
+    then "list.key=value2" returns the second element in the list. Also does "list.'key'='value2'", "list.'key'=\"value2\"",
+    "list.\"key\"='value2'" or "list.\"key\"=\"value2\"".
 
     There is not limit in the nested levels of dotted tokens, so a key like a.b.c.d will be tried to be resolved as:
 
@@ -620,6 +631,13 @@ def get_value_from_context(param, context):
 
 
 def _select_element_in_list(the_list, expression):
+    """
+    Select an element in the list that matches the key=value expression.
+    
+    :param the_list: list of dictionaries
+    :param expression: key=value expression
+    :return: the element in the list that matches the key=value expression
+    """
     if not expression:
         return None
     tokens = expression.split('=')

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -620,19 +620,18 @@ def get_value_from_context(param, context):
 
 
 def _select_element_in_list(the_list, expression):
-    if len(expression) < 3:
+    if not expression:
         return None
-    if expression[0] != '[' or expression[-1] != ']':
-        return None
-    expression = expression[1:-1]
     tokens = expression.split('=')
     if len(tokens) != 2:
         return None
     key = tokens[0]
+    if len(key) == 0:
+        return None
     value = tokens[1]
     for idx, item in enumerate(the_list):
         if key in item and item[key] == value:
-            return idx
+            return the_list[idx]
     return None
 
 
@@ -650,7 +649,7 @@ def _get_value_context_error_msg(value, part):
         if part.isdigit():
             return f"Invalid index '{part}', list size is '{len(value)}'. {part} >= {len(value)}."
         else:
-            return f"the expression '{part}' must be a numeric index or a valid key=value expression to select an element in a list"
+            return f"the element '{part}' must be a numeric index or a valid key=value expression to select an element in a list"
     else:
         return f"'{part}' attribute not found in {type(value).__name__} class in context"
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -631,7 +631,7 @@ def _select_element_in_list(the_list, expression):
     value = tokens[1]
 
     def _trim_quotes(value):
-        if len(value) > 2 and value[0] == value[-1] and value[0] in ['"', "'"]:
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ['"', "'"]:
             return value[1:-1]
         return value
  

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -589,8 +589,8 @@ def get_value_from_context(param, context):
         {"key": "value1", "attr": "attr1"},
         {"key": "value2", "attr": "attr2"}
     ]
-    then "list.key=value2" returns the second element in the list. Also does "list.'key'='value2'", "list.'key'=\"value2\"",
-    "list.\"key\"='value2'" or "list.\"key\"=\"value2\"".
+    then "list.key=value2" returns the second element in the list. Also does "list.'key'='value2'",
+    "list.'key'=\"value2\"", "list.\"key\"='value2'" or "list.\"key\"=\"value2\"".
 
     There is not limit in the nested levels of dotted tokens, so a key like a.b.c.d will be tried to be resolved as:
 
@@ -633,7 +633,7 @@ def get_value_from_context(param, context):
 def _select_element_in_list(the_list, expression):
     """
     Select an element in the list that matches the key=value expression.
-    
+
     :param the_list: list of dictionaries
     :param expression: key=value expression
     :return: the element in the list that matches the key=value expression
@@ -652,7 +652,7 @@ def _select_element_in_list(the_list, expression):
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ['"', "'"]:
             return value[1:-1]
         return value
- 
+
     key = _trim_quotes(key)
     value = _trim_quotes(value)
     for idx, item in enumerate(the_list):

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -629,6 +629,14 @@ def _select_element_in_list(the_list, expression):
     if len(key) == 0:
         return None
     value = tokens[1]
+
+    def _trim_quotes(value):
+        if len(value) > 2 and value[0] == value[-1] and value[0] in ['"', "'"]:
+            return value[1:-1]
+        return value
+ 
+    key = _trim_quotes(key)
+    value = _trim_quotes(value)
     for idx, item in enumerate(the_list):
         if key in item and item[key] == value:
             return the_list[idx]
@@ -649,7 +657,7 @@ def _get_value_context_error_msg(value, part):
         if part.isdigit():
             return f"Invalid index '{part}', list size is '{len(value)}'. {part} >= {len(value)}."
         else:
-            return f"the element '{part}' must be a numeric index or a valid key=value expression to select an element in a list"
+            return f"the expression '{part}' was not able to select an element in the list"
     else:
         return f"'{part}' attribute not found in {type(value).__name__} class in context"
 


### PR DESCRIPTION
So far....

Expressions starting with CONTEXT let us select elements saved in context or context.storage like
```
[CONTEXT:a.b.c] returns the 'c' property of the 'b' property of the 'a' element in the context
```
recently, the index in arrays was added, so that
```
[CONTEXT:a.1.b] returns the 'b' property of the element with index 1 in the 'a' array
```

Now...
let's go a bit deeper and let's have a mechanism of selecting elements in an array of dictionaries by searching for an specific key, like this:

having this next structure saved in the context
```json
   {
        "the_array": [
            {
                "id": "first-element",
                "text": "The value of the first element"
            },
            {
                "id": "second-element",
                "text": "The value of the second element"
            }
        ]
    }
```

we are now able to select like **`[CONTEXT:the_array.id=first-element.text]`** and the 'The value of the first element' will be returned

you can also use single or double quotes for the selection expression (id='first-element', "id"="first-element", etc..)
