### PR TITLE
bug(QAWTO-212): fix result for action before the feature error with background

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ v3.1.5
 - Fix `export_poeditor_project` method allowing empty export response
 - Add `key=value` expressions for selecting elements in the context storage
 - Upgrade Faker version to 25.9.*
+- Fix result for action before the feature with error and background to fail scenarios
 
 v3.1.4
 ------

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -303,7 +303,7 @@ class DynamicEnvironment:
                 if scenario.should_run(context.config):
                     self.fail_first_step_precondition_exception(scenario, error_message)
                     if len(scenario.background_steps) > 0:
-                        context.logger.warn(f'Background from scenario status udpated to fail')
+                        context.logger.warn('Background from scenario status udpated to fail')
             raise Exception(f'Before feature steps have failed: {error_message}')
 
     def fail_first_step_precondition_exception(self, scenario, error_message):

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -19,9 +19,6 @@ limitations under the License.
 import sys
 import warnings
 
-# Behave is an optional dependency in toolium, so it is imported here
-from behave.model_core import Status
-
 # Actions types defined in feature files
 ACTIONS_BEFORE_FEATURE = 'actions before the feature'
 ACTIONS_BEFORE_SCENARIO = 'actions before each scenario'
@@ -313,6 +310,8 @@ class DynamicEnvironment:
         :param scenario: Behave's Scenario
         :param error_message: Exception message
         """
+        # Behave is an optional dependency in toolium, so it is imported here
+        from behave.model_core import Status
         if len(scenario.steps) > 0:
             scenario.steps[0].status = Status.failed
             scenario.steps[0].exception = Exception('Preconditions failed')

--- a/toolium/test/behave/test_env_utils.py
+++ b/toolium/test/behave/test_env_utils.py
@@ -222,7 +222,7 @@ def test_execute_after_feature_steps_failed_before_feature(context, dyn_env):
     assert dyn_env.before_error_message is None
     context.execute_steps.assert_called_with('Given after feature step')
     context.feature.reset.assert_called_once_with()
-    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(context.scenario)
+    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(context.scenario, 'Exception in before feature step')
 
 
 def test_execute_after_feature_steps_failed_actions_failed_before_feature(context, dyn_env):
@@ -241,7 +241,7 @@ def test_execute_after_feature_steps_failed_actions_failed_before_feature(contex
     assert dyn_env.before_error_message is None
     context.execute_steps.assert_called_with('Given after feature step')
     context.feature.reset.assert_called_once_with()
-    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(context.scenario)
+    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(context.scenario, 'Exception in before feature step')
 
 
 def test_fail_first_step_precondition_exception(dyn_env):
@@ -251,7 +251,7 @@ def test_fail_first_step_precondition_exception(dyn_env):
     scenario.steps = [step1, step2]
     dyn_env.before_error_message = 'Exception in before feature step'
 
-    dyn_env.fail_first_step_precondition_exception(scenario)
+    dyn_env.fail_first_step_precondition_exception(scenario, dyn_env.before_error_message)
     assert step1.status == 'failed'
     assert str(step1.exception) == 'Preconditions failed'
     assert step1.error_message == 'Exception in before feature step'
@@ -262,4 +262,4 @@ def test_fail_first_step_precondition_exception_without_steps(dyn_env):
     scenario.steps = []
     dyn_env.before_error_message = 'Exception in before feature step'
 
-    dyn_env.fail_first_step_precondition_exception(scenario)
+    dyn_env.fail_first_step_precondition_exception(scenario, dyn_env.before_error_message)

--- a/toolium/test/behave/test_env_utils.py
+++ b/toolium/test/behave/test_env_utils.py
@@ -222,7 +222,8 @@ def test_execute_after_feature_steps_failed_before_feature(context, dyn_env):
     assert dyn_env.before_error_message is None
     context.execute_steps.assert_called_with('Given after feature step')
     context.feature.reset.assert_called_once_with()
-    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(context.scenario, 'Exception in before feature step')
+    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(
+        context.scenario, 'Exception in before feature step')
 
 
 def test_execute_after_feature_steps_failed_actions_failed_before_feature(context, dyn_env):
@@ -241,7 +242,8 @@ def test_execute_after_feature_steps_failed_actions_failed_before_feature(contex
     assert dyn_env.before_error_message is None
     context.execute_steps.assert_called_with('Given after feature step')
     context.feature.reset.assert_called_once_with()
-    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(context.scenario, 'Exception in before feature step')
+    dyn_env.fail_first_step_precondition_exception.assert_called_once_with(
+        context.scenario, 'Exception in before feature step')
 
 
 def test_fail_first_step_precondition_exception(dyn_env):


### PR DESCRIPTION
## Description

fix: dynamic environment error output for a feature with:
* action before the feature with error in step
* with background

## Current output

Current output scenarios without failure because `background` is not updated with fail status and this lead to false positives for scenarios:
```shell
0 features passed, 1 failed, 0 skipped
0 scenarios passed, 0 failed, 0 skipped, **2 untested**
0 steps passed, 2 failed, 0 skipped, 0 undefined, 2 untested
```

## Corrected output

Scenarios with background fail because actions before the feature fails, console log:
```shell
0 features passed, 1 failed, 0 skipped
0 scenarios passed, **2 failed**, 0 skipped
0 steps passed, 2 failed, 0 skipped, 0 undefined
```

To generate correct report xml output:
```xml
<testsuite name="1_fail.Fail feature with a single scenario" tests="2" errors="2"
  failures="0" skipped="0" time="0.0" timestamp="2024-06-28T13:14:40.358338"
  hostname="localhost">
  <testcase classname="1_fail.Fail feature with a single scenario"
    name="First scenario won't be executed due to failed before feature" status="failed" time="0">
    <error type="Exception" message="Preconditions failed">
<![CDATA[
Failing step: Given this step won't be executed ... failed in 0.000s
Location: features/integration/fail.feature:11
FAILED SUB-STEP: Given a failed step
Substep info: Assertion Failed: FAILED SUB-STEP: Given a failed sub-step exception
Substep info: Traceback (most recent call last):
    raise Exception("Sorry, no lucky day!")
]]>
</error>
    <system-out>
<![CDATA[
@scenario.begin

  @regression @sanity
  Scenario: First scenario won't be executed due to failed before feature
    Given this step won't be executed ... failed in 0.000s
    Given I hope this generates test report ... failed in 0.000s

@scenario.end
--------------------------------------------------------------------------------
]]>
</system-out>
  </testcase>
</testsuite>
```
