### PR TITLE
feat: improve and add new replacements to the dataset module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target
 .vscode
 
 # virtualenv
+.venv
 venv/
 VENV/
 ENV/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,10 @@ v3.2.1
 ------
 
 *Release date: In development*
-- Fix `get_value_from_context` allow negative numbers. Example: element.-1
-- Update `_replace_param_date`remove deprecated function .utcnow(), update with pytz.timezone('Europe/Madrid')
+- Update `get_value_from_context` allow negative numbers, and dictionaries elements. Example: element.-1 or element.0.value.1.key
 - Update `_replace_param_transform_string_replace_param_transform_string` include new options
   * JSON -> format string to json. Example: [JSON:{'key': 'value'}]
   * REPLACE -> replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]
-  * DATE -> format date. Example: [DATE:[CONTEXT:actual_date]::%d %b %Y]
   * TITLE -> apply .title() to string value. Example: [TITLE:the title]
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ v3.2.1
 ------
 
 *Release date: In development*
-- Update `get_value_from_context` allow negative numbers, and dictionaries elements. Example: element.-1 or element.0.value.1.key
+- Update `get_value_from_context` allow negative numbers. Example: element.-1
 - Update `_replace_param_transform_string_replace_param_transform_string` include new options
   * JSON -> format string to json. Example: [JSON:{'key': 'value'}]
   * REPLACE -> replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ v3.2.1
 
 *Release date: In development*
 - Allow negative indexes for list elements in context searches. Example: [CONTEXT:element.-1]
-- Add support for JSON strings to the `DICT` and `LIST`` replacement. Example: [DICT:{"key": true}], [LIST: null]
+- Add support for JSON strings to the `DICT` and `LIST`` replacement. Example: [DICT:{"key": true}], [LIST:[null]]
 - Add `REPLACE` replacement, to replace a substring with another. Example: [REPLACE:[CONTEXT:some_url]::https::http]
 - Add `TITLE` replacement, to apply Python's title() function. Example: [TITLE:the title]
 - Add `ROUND` replacement, float number to a string with the indicated number of decimals. Example: [ROUND:3.3333::2]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ v3.2.1
 
 *Release date: In development*
 - Allow negative indexes for list elements in context searches. Example: [CONTEXT:element.-1]
-- Add support for JSON strings to the `DICT` replacement. Example: [DICT:{"key": true}]
+- Add support for JSON strings to the `DICT` and `LIST`` replacement. Example: [DICT:{"key": true}], [LIST: null]
 - Add `REPLACE` replacement, to replace a substring with another. Example: [REPLACE:[CONTEXT:some_url]::https::http]
 - Add `TITLE` replacement, to apply Python's title() function. Example: [TITLE:the title]
 - Add `ROUND` replacement, float number to a string with the indicated number of decimals. Example: [ROUND:3.3333::2]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ v3.2.1
 ------
 
 *Release date: In development*
+- Fix `get_value_from_context` allow negative numbers. Example: element.-1
+- Update `_replace_param_date`remove deprecated function .utcnow(), update with pytz.timezone('Europe/Madrid')
+- Update `_replace_param_transform_string_replace_param_transform_string` include new options
+  * JSON -> format string to json. Example: [JSON:{'key': 'value'}]
+  * REPLACE -> replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]
+  * DATE -> format date. Example: [DATE:[CONTEXT:actual_date]::%d %b %Y]
+  * TITLE -> apply .title() to string value. Example: [TITLE:the title]
+
 
 v3.2.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ v3.2.1
 - Add support for JSON strings to the `DICT` replacement. Example: [DICT:{"key": true}]
 - Add `REPLACE` replacement, to replace a substring with another. Example: [REPLACE:[CONTEXT:some_url]::https::http]
 - Add `TITLE` replacement, to apply Python's title() function. Example: [TITLE:the title]
-- Add `ROUND` replacement, float number to a string with the expected decimals. Example: [ROUND:3.3333::2]
+- Add `ROUND` replacement, float number to a string with the indicated number of decimals. Example: [ROUND:3.3333::2]
 
 v3.2.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,10 @@ v3.2.1
 ------
 
 *Release date: In development*
-- Update `get_value_from_context` allow negative numbers. Example: element.-1
-- Update `_replace_param_transform_string_replace_param_transform_string` include new options
-  * JSON -> format string to json. Example: [JSON:{'key': 'value'}]
-  * REPLACE -> replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]
-  * TITLE -> apply .title() to string value. Example: [TITLE:the title]
+- Allow negative indexes for list elements in context searches. Example: [CONTEXT:element.-1]
+- Add support for JSON strings to the `DICT` replacement. Example: [DICT:{"key": true}]
+- Add `REPLACE` replacement, to replace a substring with another. Example: [REPLACE:[CONTEXT:some_url]::https::http]
+- Add `TITLE` replacement, to apply Python's title() function. Example: [TITLE:the title]
 
 
 v3.2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ v3.2.1
 - Add support for JSON strings to the `DICT` replacement. Example: [DICT:{"key": true}]
 - Add `REPLACE` replacement, to replace a substring with another. Example: [REPLACE:[CONTEXT:some_url]::https::http]
 - Add `TITLE` replacement, to apply Python's title() function. Example: [TITLE:the title]
-
+- Add `ROUND` replacement, float number to a string with the expected decimals. Example: [ROUND:3.3333::2]
 
 v3.2.0
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ screeninfo~=0.8
 lxml~=5.1
 Faker~=25.9
 phonenumbers~=8.13
-pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ screeninfo~=0.8
 lxml~=5.1
 Faker~=25.9
 phonenumbers~=8.13
+pytz

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -458,7 +458,7 @@ def test_a_context_param_list_correct_negative_index():
 
 def test_a_context_param_list_incorrect_negative_index():
     """
-    Verification of a list with a correct negative index (In bounds) as CONTEXT
+    Verification of a list with a incorrect negative index (In bounds) as CONTEXT
     """
     class Context(object):
         pass

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -483,7 +483,7 @@ def test_a_context_param_list_incorrect_negative_index():
     }
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
-    assert "list index out of range" == str(excinfo.value)
+    assert "the expression '-5' was not able to select an element in the list" == str(excinfo.value)
 
 
 def test_a_context_param_list_oob_index():

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -456,6 +456,33 @@ def test_a_context_param_list_correct_negative_index():
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.-1.id]") == 'ask-for-negative'
 
+def test_a_context_param_list_incorrect_negative_index():
+    """
+    Verification of a list with a correct negative index (In bounds) as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
+
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            },
+            {
+                'id': 'ask-for-negative',
+                'text': 'QA negative index'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
+    
 
 def test_a_context_param_list_oob_index():
     """

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -454,7 +454,8 @@ def test_a_context_param_list_correct_negative_index():
     }
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.-1.id]") == 'ask-for-negative'
-    
+
+
 def test_a_context_param_list_oob_index():
     """
     Verification of a list with an incorrect index (Out of bounds) as CONTEXT

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -568,7 +568,6 @@ def test_a_context_param_class_no_numeric_index():
     context.list = ExampleClass()
     dataset.behave_context = context
 
-    print(context)
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.prueba.id]")
     assert "the expression 'prueba' was not able to select an element in the list" == str(excinfo.value)

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -428,6 +428,7 @@ def test_a_context_param_list_correct_index():
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.1.id]") == 'ask-for-qa'
 
+
 def test_a_context_param_list_correct_negative_index():
     """
     Verification of a list with a correct negative index (In bounds) as CONTEXT

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -428,7 +428,33 @@ def test_a_context_param_list_correct_index():
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.1.id]") == 'ask-for-qa'
 
+def test_a_context_param_list_correct_negative_index():
+    """
+    Verification of a list with a correct negative index (In bounds) as CONTEXT
+    """
+    class Context(object):
+        pass
+    context = Context()
 
+    context.list = {
+        'cmsScrollableActions': [
+            {
+                'id': 'ask-for-duplicate',
+                'text': 'QA duplica'
+            },
+            {
+                'id': 'ask-for-qa',
+                'text': 'QA no duplica'
+            },
+            {
+                'id': 'ask-for-negative',
+                'text': 'QA negative index'
+            }
+        ]
+    }
+    dataset.behave_context = context
+    assert map_param("[CONTEXT:list.cmsScrollableActions.-1.id]") == 'ask-for-negative'
+    
 def test_a_context_param_list_oob_index():
     """
     Verification of a list with an incorrect index (Out of bounds) as CONTEXT

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -484,7 +484,7 @@ def test_a_context_param_list_incorrect_negative_index():
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
     assert "IndexError: list index out of range" == str(excinfo.value)
-    
+
 
 def test_a_context_param_list_oob_index():
     """

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -455,6 +455,7 @@ def test_a_context_param_list_correct_negative_index():
     }
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.-1.id]") == 'ask-for-negative'
+    assert map_param("[CONTEXT:list.cmsScrollableActions.-3.id]") == 'ask-for-duplicate'
 
 
 def test_a_context_param_list_incorrect_negative_index():

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -456,6 +456,7 @@ def test_a_context_param_list_correct_negative_index():
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.-1.id]") == 'ask-for-negative'
 
+
 def test_a_context_param_list_incorrect_negative_index():
     """
     Verification of a list with a incorrect negative index (In bounds) as CONTEXT
@@ -482,7 +483,7 @@ def test_a_context_param_list_incorrect_negative_index():
     }
     dataset.behave_context = context
     assert map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
-    
+
 
 def test_a_context_param_list_oob_index():
     """

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -481,9 +481,10 @@ def test_a_context_param_list_incorrect_negative_index():
             }
         ]
     }
-    dataset.behave_context = context
-    assert map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
-
+    with pytest.raises(Exception) as excinfo:
+        map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
+    assert "IndexError: list index out of range" == str(excinfo.value)
+    
 
 def test_a_context_param_list_oob_index():
     """

--- a/toolium/test/utils/test_dataset_map_param_context.py
+++ b/toolium/test/utils/test_dataset_map_param_context.py
@@ -483,7 +483,7 @@ def test_a_context_param_list_incorrect_negative_index():
     }
     with pytest.raises(Exception) as excinfo:
         map_param("[CONTEXT:list.cmsScrollableActions.-5.id]")
-    assert "IndexError: list index out of range" == str(excinfo.value)
+    assert "list index out of range" == str(excinfo.value)
 
 
 def test_a_context_param_list_oob_index():

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -439,29 +439,33 @@ def test_replace_param_partial_string_with_length():
     param = replace_param('parameter [STRING_WITH_LENGTH_5] is string')
     assert param == 'parameter aaaaa is string'
 
+
 def test_replace_param_json():
     test_json = '{"key": "value", "key_1": true}'
     param = replace_param(f'[JSON:{test_json}]')
     assert param == {"key": "value", "key_1": True}
 
-def test_replace_param_json():
-    param = replace_param(f'[REPLACE:https://url.com::https::http]')
+
+def test_replace_param_replace():
+    param = replace_param('[REPLACE:https://url.com::https::http]')
     assert param == "http://url.com"
-    param = replace_param(f'[REPLACE:https://url.com::https://]')
+    param = replace_param('[REPLACE:https://url.com::https://]')
     assert param == "url.com"
-    
+
+
 def test_replace_param_date():
-    param = replace_param(f'[DATE:1994-06-13T07:00:00::%d %m %Y]')
+    param = replace_param('[DATE:1994-06-13T07:00:00::%d %m %Y]')
     assert param == "13 06 1994"
-    param = replace_param(f'[DATE:1994-06-13T07:00:00::%d %b %Y]')
+    param = replace_param('[DATE:1994-06-13T07:00:00::%d %b %Y]')
     assert param == "13 JUN 1994"
-    param = replace_param(f'[DATE:1994-06-13T07:00:00::%H:%M]')
+    param = replace_param('[DATE:1994-06-13T07:00:00::%H:%M]')
     assert param == "07:00"
-    
+
+
 def test_replace_param_title():
-    param = replace_param(f'[TITLE:hola hola]')
+    param = replace_param('[TITLE:hola hola]')
     assert param == "Hola Hola"
-    param = replace_param(f'[TITLE:holahola]')
+    param = replace_param('[TITLE:holahola]')
     assert param == "Holahola"
-    param = replace_param(f'[TITLE:hOlA]')
+    param = replace_param('[TITLE:hOlA]')
     assert param == "Hola"

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -333,6 +333,13 @@ def test_replace_param_now_offsets_with_and_without_format_and_more():
     assert param == f'The date {offset_date} was yesterday and I have an appointment at {offset_datetime}'
 
 
+def test_replace_param_round_without_type_inference():
+    param = replace_param('[ROUND:7.5::2]')
+    assert param == 7.5
+    param = replace_param('[ROUND:3.33333333::3]')
+    assert param == 3.333
+
+
 def test_replace_param_str_int():
     param = replace_param('[STR:28]')
     assert isinstance(param, str)
@@ -459,17 +466,3 @@ def test_replace_param_title():
     assert param == "Holahola"
     param = replace_param('[TITLE:hOlA]')
     assert param == "HOlA"
-
-
-def test_replace_param_round_with_type_inference():
-    param = replace_param('[ROUND:7.5::2]')
-    assert param == 7.5
-    param = replace_param('[ROUND:3.33333333::3]')
-    assert param == 3.333
-
-
-def test_replace_param_round_without_type_inference():
-    param = replace_param('[ROUND:7.500::2]', infer_param_type=False)
-    assert param == '7.50'
-    param = replace_param('[ROUND:3.33333333::3]', infer_param_type=False)
-    assert param == '3.333'

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -376,10 +376,8 @@ def test_replace_param_dict():
 
 
 def test_replace_param_dict_json_format():
-    param = replace_param('[DICT:{"key": "value", "key_2": true}]')
-    assert param == {"key": "value", "key_2": True}
-    param = replace_param('[DICT:{"key": "value", "key_2": null}]')
-    assert param == {"key": "value", "key_2": None}
+    param = replace_param('[DICT:{"key": "value", "key_2": true, "key_3": null}]')
+    assert param == {"key": "value", "key_2": True, "key_3": None}
 
 
 def test_replace_param_upper():

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -383,6 +383,11 @@ def test_replace_param_list_strings():
     assert param == ['1', '2', '3']
 
 
+def test_replace_param_list_json_format():
+    param = replace_param('[LIST:["value", true, null]]')
+    assert param == ["value", True, None]
+
+
 def test_replace_param_dict():
     param = replace_param("[DICT:{'a':'test1','b':'test2','c':'test3'}]")
     assert isinstance(param, dict)

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -438,3 +438,30 @@ def test_replace_param_partial_string_with_length():
     assert param == 'aaaaa is string'
     param = replace_param('parameter [STRING_WITH_LENGTH_5] is string')
     assert param == 'parameter aaaaa is string'
+
+def test_replace_param_json():
+    test_json = '{"key": "value", "key_1": true}'
+    param = replace_param(f'[JSON:{test_json}]')
+    assert param == {"key": "value", "key_1": True}
+
+def test_replace_param_json():
+    param = replace_param(f'[REPLACE:https://url.com::https::http]')
+    assert param == "http://url.com"
+    param = replace_param(f'[REPLACE:https://url.com::https://]')
+    assert param == "url.com"
+    
+def test_replace_param_date():
+    param = replace_param(f'[DATE:1994-06-13T07:00:00::%d %m %Y]')
+    assert param == "13 06 1994"
+    param = replace_param(f'[DATE:1994-06-13T07:00:00::%d %b %Y]')
+    assert param == "13 JUN 1994"
+    param = replace_param(f'[DATE:1994-06-13T07:00:00::%H:%M]')
+    assert param == "07:00"
+    
+def test_replace_param_title():
+    param = replace_param(f'[TITLE:hola hola]')
+    assert param == "Hola Hola"
+    param = replace_param(f'[TITLE:holahola]')
+    assert param == "Holahola"
+    param = replace_param(f'[TITLE:hOlA]')
+    assert param == "Hola"

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -453,15 +453,6 @@ def test_replace_param_replace():
     assert param == "url.com"
 
 
-def test_replace_param_date():
-    param = replace_param('[DATE:1994-06-13T07:00:00::%d %m %Y]')
-    assert param == "13 06 1994"
-    param = replace_param('[DATE:1994-06-13T07:00:00::%d %b %Y]')
-    assert param == "13 JUN 1994"
-    param = replace_param('[DATE:1994-06-13T07:00:00::%H:%M]')
-    assert param == "07:00"
-
-
 def test_replace_param_title():
     param = replace_param('[TITLE:hola hola]')
     assert param == "Hola Hola"

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -440,12 +440,6 @@ def test_replace_param_partial_string_with_length():
     assert param == 'parameter aaaaa is string'
 
 
-def test_replace_param_json():
-    test_json = '{"key": "value", "key_1": true}'
-    param = replace_param(f'[JSON:{test_json}]')
-    assert param == {"key": "value", "key_1": True}
-
-
 def test_replace_param_replace():
     param = replace_param('[REPLACE:https://url.com::https::http]')
     assert param == "http://url.com"

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -377,9 +377,9 @@ def test_replace_param_dict():
 
 def test_replace_param_dict_json_format():
     param = replace_param('[DICT:{"key": "value", "key_2": true}]')
-    assert param == '{"key": "value", "key_2": True}'
+    assert param == {"key": "value", "key_2": True}
     param = replace_param('[DICT:{"key": "value", "key_2": null}]')
-    assert param == '{"key": "value", "key_2": null}'
+    assert param == {"key": "value", "key_2": None}
 
 
 def test_replace_param_upper():

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -375,6 +375,13 @@ def test_replace_param_dict():
     assert param == {'a': 'test1', 'b': 'test2', 'c': 'test3'}
 
 
+def test_replace_param_dict_json_format():
+    param = replace_param('[DICT:{"key": "value", "key_2": true}]')
+    assert param == '{"key": "value", "key_2": true}'
+    param = replace_param('[DICT:{"key": "value", "key_2": null}]')
+    assert param == '{"key": "value", "key_2": null}'
+
+
 def test_replace_param_upper():
     param = replace_param('[UPPER:test]')
     assert param == 'TEST'
@@ -454,3 +461,10 @@ def test_replace_param_title():
     assert param == "Holahola"
     param = replace_param('[TITLE:hOlA]')
     assert param == "HOlA"
+
+
+def test_replace_param_round():
+    param = replace_param('[ROUND:7.5::2]')
+    assert param == "7.50"
+    param = replace_param('[ROUND:3.33333333::3]')
+    assert param == "3.333"

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -461,8 +461,15 @@ def test_replace_param_title():
     assert param == "HOlA"
 
 
-def test_replace_param_round():
+def test_replace_param_round_with_type_inference():
     param = replace_param('[ROUND:7.5::2]')
     assert param == 7.5
     param = replace_param('[ROUND:3.33333333::3]')
     assert param == 3.333
+
+
+def test_replace_param_round_without_type_inference():
+    param = replace_param('[ROUND:7.500::2]', infer_param_type=False)
+    assert param == '7.50'
+    param = replace_param('[ROUND:3.33333333::3]', infer_param_type=False)
+    assert param == '3.333'

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -333,11 +333,18 @@ def test_replace_param_now_offsets_with_and_without_format_and_more():
     assert param == f'The date {offset_date} was yesterday and I have an appointment at {offset_datetime}'
 
 
-def test_replace_param_round_without_type_inference():
+def test_replace_param_round_with_type_inference():
     param = replace_param('[ROUND:7.5::2]')
     assert param == 7.5
     param = replace_param('[ROUND:3.33333333::3]')
     assert param == 3.333
+
+
+def test_replace_param_round_without_type_inference():
+    param = replace_param('[ROUND:7.500::2]', infer_param_type=False)
+    assert param == '7.50'
+    param = replace_param('[ROUND:3.33333333::3]', infer_param_type=False)
+    assert param == '3.333'
 
 
 def test_replace_param_str_int():

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -463,6 +463,6 @@ def test_replace_param_title():
 
 def test_replace_param_round():
     param = replace_param('[ROUND:7.5::2]')
-    assert param == "7.50"
+    assert param == 7.5
     param = replace_param('[ROUND:3.33333333::3]')
-    assert param == "3.333"
+    assert param == 3.333

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -459,4 +459,4 @@ def test_replace_param_title():
     param = replace_param('[TITLE:holahola]')
     assert param == "Holahola"
     param = replace_param('[TITLE:hOlA]')
-    assert param == "Hola"
+    assert param == "HOlA"

--- a/toolium/test/utils/test_dataset_replace_param.py
+++ b/toolium/test/utils/test_dataset_replace_param.py
@@ -377,7 +377,7 @@ def test_replace_param_dict():
 
 def test_replace_param_dict_json_format():
     param = replace_param('[DICT:{"key": "value", "key_2": true}]')
-    assert param == '{"key": "value", "key_2": true}'
+    assert param == '{"key": "value", "key_2": True}'
     param = replace_param('[DICT:{"key": "value", "key_2": null}]')
     assert param == '{"key": "value", "key_2": null}'
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -256,7 +256,7 @@ def _replace_param_transform_string(param):
 
     if type_mapping_match_group:
         param_transformed = True
-        if type_mapping_match_group.group(1) == ['DICT', 'LIST']:
+        if type_mapping_match_group.group(1) in ['DICT', 'LIST']:
             try:
                 new_param = json.loads(type_mapping_match_group.group(2).strip())
             except json.decoder.JSONDecodeError:

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -288,30 +288,31 @@ def _update_param_transform_string(type_mapping_match_group):
     """
     Transform param value according to the specified prefix.
     Available transformations: STR, UPPER, LOWER, REPLACE, DATE, TITLE
-    
+
     :param type_mapping_match_group: match group
     :return: return the string with the replaced param
     """
     if type_mapping_match_group.group(1) == 'STR':
         replace_param = type_mapping_match_group.group(2)
-    elif type_mapping_match_group.group(1)  == 'UPPER':
+    elif type_mapping_match_group.group(1) == 'UPPER':
         replace_param = type_mapping_match_group.group(2).upper()
-    elif type_mapping_match_group.group(1)  == 'LOWER':
+    elif type_mapping_match_group.group(1) == 'LOWER':
         replace_param = type_mapping_match_group.group(2).lower()
-    elif type_mapping_match_group.group(1)  == 'REPLACE':
+    elif type_mapping_match_group.group(1) == 'REPLACE':
         params_to_replace = type_mapping_match_group.group(2).split('::')
         replace_param = params_to_replace[2] if len(params_to_replace) > 2 else ''
         param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\n' else '\n'
         param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\r' else '\r'
         replace_param = params_to_replace[0].replace(param_to_replace, replace_param)\
             .replace('  ', ' ').replace('  ', ' ')
-    elif type_mapping_match_group.group(1)  == 'DATE':
+    elif type_mapping_match_group.group(1) == 'DATE':
         params_to_replace = type_mapping_match_group.group(2).split('::')
         date_actual_format = '%Y/%m/%d %H:%M:%S'
-        replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format, \
-            capitalize=False)
-    elif type_mapping_match_group.group(1)  == 'TITLE':
-        replace_param = "".join(map(min, zip(type_mapping_match_group.group(2), type_mapping_match_group.group(2).title())))
+        replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format, 
+                                            capitalize=False)
+    elif type_mapping_match_group.group(1) == 'TITLE':
+        replace_param = "".join(map(min, zip(type_mapping_match_group.group(2), 
+                                             type_mapping_match_group.group(2).title())))
     return replace_param
 
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -261,7 +261,7 @@ def _replace_param_transform_string(param):
                 new_param = json.loads(type_mapping_match_group.group(2).strip())
             except json.decoder.JSONDecodeError:
                 new_param = eval(type_mapping_match_group.group(2))
-        elif type_mapping_match_group.group(1) in ['DICT', 'LIST', 'INT', 'FLOAT']:
+        elif type_mapping_match_group.group(1) in ['LIST', 'INT', 'FLOAT']:
             exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
             new_param = locals()['exec_param']
         else:

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -229,13 +229,12 @@ def _get_rounded_float_number(param):
     :param param: param to format
     :return: float as string with the expected decimals
     """
-    type_mapping_regex = r'\[(ROUND):([\w\W]*)\]'
-    type_mapping_match_group = re.match(type_mapping_regex, param)
-    if type_mapping_match_group and type_mapping_match_group.group(1) == 'ROUND':
-        replace_params = type_mapping_match_group.group(2).split('::')
-        replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])}f}"
-        return replace_param
-    return ''
+    type_regex = r'\[(ROUND):(.*)::(\d)*\]'
+    type_match = re.match(type_regex, param)
+    if type_match and type_match.group(1) == 'ROUND':
+        if type_match.group(3).isdigit():
+            replace_param = f"{round(float(type_match.group(2)), int(type_match.group(3))):.{int(type_match.group(3))}f}"
+            return replace_param
 
 
 def _get_random_phone_number():

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -27,8 +27,6 @@ import re
 import string
 import uuid
 
-
-
 from ast import literal_eval
 from copy import deepcopy
 from inspect import isfunction
@@ -648,12 +646,7 @@ def get_value_from_context(param, context):
             value = value[part]
         # evaluate if in an array, access is requested by index
         elif isinstance(value, list) and part.lstrip('-+').isdigit() and int(part) < len(value):
-            try:
-                value = value[int(part)] if part.lstrip('-+').isdigit() else value[part]
-            except (TypeError, KeyError):
-                value = getattr(value, part)
-            except AttributeError as exc:
-                raise AttributeError(context.logger.info) from exc
+            value = value[int(part)]
         # or by a key=value expression
         elif isinstance(value, list) and (element := _select_element_in_list(value, part)):
             value = element

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -89,7 +89,7 @@ def replace_param(param, language='es', infer_param_type=True):
         [DICT:xxxx] Cast xxxx to a dict
         [UPPER:xxxx] Converts xxxx to upper case
         [LOWER:xxxx] Converts xxxx to lower case
-        [REPLACE:xxxxx::xx::zz] Replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]
+        [REPLACE:xxxxx::yy::zz] Replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]
         [TITLE:xxxxx] Apply .title() to string value. Example: [TITLE:the title]
     If infer_param_type is True and the result of the replacement process is a string,
     this function also tries to infer and cast the result to the most appropriate data type,

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -256,15 +256,14 @@ def _replace_param_transform_string(param):
 
     if type_mapping_match_group:
         param_transformed = True
-        if type_mapping_match_group.group(1) in ['DICT', 'LIST', 'INT', 'FLOAT']:
-            if type_mapping_match_group.group(1) == 'DICT':
-                try:
-                    new_param = json.loads(type_mapping_match_group.group(2).strip())
-                except json.decoder.JSONDecodeError:
-                    new_param = eval(type_mapping_match_group.group(2))
-            else:
-                exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
-                new_param = locals()['exec_param']
+        if type_mapping_match_group.group(1) == 'DICT':
+            try:
+                new_param = json.loads(type_mapping_match_group.group(2).strip())
+            except json.decoder.JSONDecodeError:
+                new_param = eval(type_mapping_match_group.group(2))
+        elif type_mapping_match_group.group(1) in ['DICT', 'LIST', 'INT', 'FLOAT']:
+            exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
+            new_param = locals()['exec_param']
         else:
             replace_param = _get_substring_replacement(type_mapping_match_group)
             new_param = new_param.replace(type_mapping_match_group.group(), replace_param)

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -224,8 +224,6 @@ def _replace_param_replacement(param, language):
             new_value = value(match)  # a function to parse the values is always required
             new_param = new_param.replace(match.group(), new_value)
             param_replaced = True
-    print(new_param)
-    print(param_replaced)
     return new_param, param_replaced
 
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -646,7 +646,7 @@ def get_value_from_context(param, context):
         if isinstance(value, dict) and part in value:
             value = value[part]
         # evaluate if in an array, access is requested by index
-        elif isinstance(value, list) and part.lstrip('-+').isdigit() and int(part) < len(value):
+        elif isinstance(value, list) and part.lstrip('-+').isdigit() and int(part) <= len(value):
             value = value[int(part)]
         # or by a key=value expression
         elif isinstance(value, list) and (element := _select_element_in_list(value, part)):

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -646,7 +646,7 @@ def get_value_from_context(param, context):
         if isinstance(value, dict) and part in value:
             value = value[part]
         # evaluate if in an array, access is requested by index
-        elif isinstance(value, list) and part.lstrip('-+').isdigit() and int(part) <= len(value):
+        elif isinstance(value, list) and part.lstrip('-+').isdigit() and int(part) < len(value):
             value = value[int(part)]
         # or by a key=value expression
         elif isinstance(value, list) and (element := _select_element_in_list(value, part)):

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -231,7 +231,7 @@ def _get_rounded_float_number(param):
     """
     type_mapping_regex = r'\[(ROUND):([\w\W]*)\]'
     type_mapping_match_group = re.match(type_mapping_regex, param)
-    if type_mapping_match_group and type_mapping_match_group.group(1) == 'ROUND':     
+    if type_mapping_match_group and type_mapping_match_group.group(1) == 'ROUND':
         replace_params = type_mapping_match_group.group(2).split('::')
         replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])}f}"
         return replace_param

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -256,12 +256,12 @@ def _replace_param_transform_string(param):
 
     if type_mapping_match_group:
         param_transformed = True
-        if type_mapping_match_group.group(1) == 'DICT':
+        if type_mapping_match_group.group(1) == ['DICT', 'LIST']:
             try:
                 new_param = json.loads(type_mapping_match_group.group(2).strip())
             except json.decoder.JSONDecodeError:
                 new_param = eval(type_mapping_match_group.group(2))
-        elif type_mapping_match_group.group(1) in ['LIST', 'INT', 'FLOAT']:
+        elif type_mapping_match_group.group(1) in ['INT', 'FLOAT']:
             exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
             new_param = locals()['exec_param']
         else:

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -84,7 +84,7 @@ def replace_param(param, language='es', infer_param_type=True):
         [STR:xxxx] Cast xxxx to a string
         [INT:xxxx] Cast xxxx to an int
         [FLOAT:xxxx] Cast xxxx to a float
-        [ROUND:xxxx::d] String float with the expected decimals
+        [ROUND:xxxx::y] Generates a string from a float number (xxxx) with the indicated number of decimals (y)
         [LIST:xxxx] Cast xxxx to a list
         [DICT:xxxx] Cast xxxx to a dict
         [UPPER:xxxx] Converts xxxx to upper case
@@ -221,6 +221,7 @@ def _replace_param_replacement(param, language):
             new_param = new_param.replace(key, new_value)
             param_replaced = True
     return new_param, param_replaced
+
 
 def _get_rounded_float_number(param):
     """

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -90,7 +90,6 @@ def replace_param(param, language='es', infer_param_type=True):
         [LOWER:xxxx] Converts xxxx to lower case
         [JSON:xxxxx] Format string to json. Example: [JSON:{'key': 'value'}]
         [REPLACE:xxxxx::xx::zz] Replace elements in string. Example: [REPLACE:[CONTEXT:some_url]::https::http]
-        [DATE:xxxx::{date-format}] Format date. Example: [DATE:[CONTEXT:actual_date]::%d %b %Y]
         [TITLE:xxxxx] Apply .title() to string value. Example: [TITLE:the title]
     If infer_param_type is True and the result of the replacement process is a string,
     this function also tries to infer and cast the result to the most appropriate data type,
@@ -262,7 +261,7 @@ def _replace_param_transform_string(param):
 def _update_param_transform_string(type_mapping_match_group):
     """
     Transform param value according to the specified prefix.
-    Available transformations: STR, UPPER, LOWER, REPLACE, DATE, TITLE
+    Available transformations: STR, UPPER, LOWER, REPLACE, TITLE
 
     :param type_mapping_match_group: match group
     :return: return the string with the replaced param
@@ -278,8 +277,7 @@ def _update_param_transform_string(type_mapping_match_group):
         replace_param = params_to_replace[2] if len(params_to_replace) > 2 else ''
         param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\n' else '\n'
         param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\r' else '\r'
-        replace_param = params_to_replace[0].replace(param_to_replace, replace_param)\
-            .replace('  ', ' ').replace('  ', ' ')
+        replace_param = params_to_replace[0].replace(param_to_replace, replace_param)
     elif type_mapping_match_group.group(1) == 'TITLE':
         replace_param = "".join(map(min, zip(type_mapping_match_group.group(2),
                                              type_mapping_match_group.group(2).title())))

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -205,7 +205,6 @@ def _replace_param_replacement(param, language):
         '[NOW]': str(datetime.datetime.utcnow().strftime(date_format)),
         '[TODAY]': str(datetime.datetime.utcnow().strftime(date_day_format)),
         '[ROUND:.*::.*]': _get_rounded_float_number(param)
-        
     }
 
     # append date expressions found in param to the replacement dict

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -251,12 +251,12 @@ def _replace_param_transform_string(param):
                 exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
                 new_param = locals()['exec_param']
         else:
-            replace_param = _update_param_transform_string(type_mapping_match_group)
+            replace_param = _get_substring_replacement(type_mapping_match_group)
             new_param = new_param.replace(type_mapping_match_group.group(), replace_param)
     return new_param, param_transformed
 
 
-def _update_param_transform_string(type_mapping_match_group):
+def _get_substring_replacement(type_mapping_match_group):
     """
     Transform param value according to the specified prefix.
     Available transformations: STR, UPPER, LOWER, REPLACE, TITLE, ROUND
@@ -646,7 +646,7 @@ def get_value_from_context(param, context):
             value = value[part]
         # evaluate if in an array, access is requested by index
         elif isinstance(value, list) and part.lstrip('-+').isdigit() \
-                and int(part) < (len(value) + 1 if part.startswith("-") else len(value)):
+                and abs(int(part)) < (len(value) + 1 if part.startswith("-") else len(value)):
             value = value[int(part)]
         # or by a key=value expression
         elif isinstance(value, list) and (element := _select_element_in_list(value, part)):

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -81,10 +81,10 @@ def replace_param(param, language='es', infer_param_type=True):
         [NOW(%Y-%m-%dT%H:%M:%SZ) - 7 DAYS] Similar to NOW but seven days before and with the indicated format
         [TODAY] Similar to NOW without time; the format depends on the language
         [TODAY + 2 DAYS] Similar to NOW, but two days later
+        [ROUND:xxxx::y] Generates a string from a float number (xxxx) with the indicated number of decimals (y)
         [STR:xxxx] Cast xxxx to a string
         [INT:xxxx] Cast xxxx to an int
         [FLOAT:xxxx] Cast xxxx to a float
-        [ROUND:xxxx::y] Generates a string from a float number (xxxx) with the indicated number of decimals (y)
         [LIST:xxxx] Cast xxxx to a list
         [DICT:xxxx] Cast xxxx to a dict
         [UPPER:xxxx] Converts xxxx to upper case

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -308,7 +308,7 @@ def _update_param_transform_string(type_mapping_match_group):
     elif type_mapping_match_group.group(1) == 'DATE':
         params_to_replace = type_mapping_match_group.group(2).split('::')
         date_actual_format = '%Y/%m/%d %H:%M:%S'
-        replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format, 
+        replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format,
                                              capitalize=False)
     elif type_mapping_match_group.group(1) == 'TITLE':
         replace_param = "".join(map(min, zip(type_mapping_match_group.group(2),

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -226,6 +226,7 @@ def _get_random_phone_number():
     # Method to avoid executing data generator when it is not needed
     return DataGenerator().phone_number
 
+
 def _replace_param_transform_string(param):
     """
     Transform param value according to the specified prefix.

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -230,7 +230,7 @@ def _get_random_phone_number():
 
 
 def _format_date_spanish(date, date_expected_format, date_actual_format='%Y-%m-%dT%H:%M:%SZ', capitalize=True):
-    """_format_date_spanish 
+    """_format_date_spanish
     Format date to spanish
 
     :param str date: actual date
@@ -250,6 +250,7 @@ def _format_date_spanish(date, date_expected_format, date_actual_format='%Y-%m-%
             formated_date = formated_date if formated_date[0] != '0' else formated_date[1:]
 
     return formated_date
+
 
 def _replace_param_transform_string(param):
     """
@@ -292,8 +293,9 @@ def _replace_param_transform_string(param):
                 replace_param = params_to_replace[0].replace(param_to_replace, replace_param).replace('  ', ' ').replace('  ', ' ')
             elif type_mapping_match_group.group(1) == 'DATE':
                 params_to_replace = type_mapping_match_group.group(2).split('::')
-                date_actual_format='%Y/%m/%d %H:%M:%S'
-                replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format, capitalize=False)
+                date_actual_format = '%Y/%m/%d %H:%M:%S'
+                replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format,\
+                    capitalize=False)
             elif type_mapping_match_group.group(1) == 'TITLE':
                 replace_param = "".join(map(min, zip(type_mapping_match_group.group(2),
                                                      type_mapping_match_group.group(2).title())))
@@ -317,7 +319,7 @@ def _replace_param_date(param, language):
     def _date_matcher():
         return re.match(r'\[(NOW(?:\((?:.*)\)|)|TODAY)(?:\s*([\+|-]\s*\d+)\s*(\w+)\s*)?\]', param)
 
-    def _offset_datetime(amount, units): 
+    def _offset_datetime(amount, units):
         now = datetime.datetime.now(pytz.timezone('Europe/Madrid'))
         if not amount or not units:
             return now

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -241,11 +241,8 @@ def _replace_param_transform_string(param):
 
     if type_mapping_match_group:
         param_transformed = True
-        if type_mapping_match_group.group(1) in ['DICT', 'LIST', 'INT', 'FLOAT', 'ROUND']:
-            if '::' in type_mapping_match_group.group() and 'ROUND' in type_mapping_match_group.group():
-                params_to_replace = type_mapping_match_group.group(2).split('::')
-                new_param = f"{round(float(params_to_replace[0]), int(params_to_replace[1])):.{int(params_to_replace[1])}f}"
-            elif type_mapping_match_group.group(1) == 'DICT':
+        if type_mapping_match_group.group(1) in ['DICT', 'LIST', 'INT', 'FLOAT']:
+            if type_mapping_match_group.group(1) == 'DICT':
                 try:
                     new_param = json.loads(type_mapping_match_group.group(2).strip())
                 except json.decoder.JSONDecodeError:
@@ -282,6 +279,9 @@ def _update_param_transform_string(type_mapping_match_group):
     elif type_mapping_match_group.group(1) == 'TITLE':
         replace_param = "".join(map(min, zip(type_mapping_match_group.group(2),
                                              type_mapping_match_group.group(2).title())))
+    elif type_mapping_match_group.group(1) == 'ROUND':
+        replace_params = type_mapping_match_group.group(2).split('::')
+        replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])} f }"
     return replace_param
 
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -259,7 +259,7 @@ def _replace_param_transform_string(param):
 def _update_param_transform_string(type_mapping_match_group):
     """
     Transform param value according to the specified prefix.
-    Available transformations: STR, UPPER, LOWER, REPLACE, TITLE
+    Available transformations: STR, UPPER, LOWER, REPLACE, TITLE, ROUND
 
     :param type_mapping_match_group: match group
     :return: return the string with the replaced param
@@ -281,7 +281,7 @@ def _update_param_transform_string(type_mapping_match_group):
                                              type_mapping_match_group.group(2).title())))
     elif type_mapping_match_group.group(1) == 'ROUND':
         replace_params = type_mapping_match_group.group(2).split('::')
-        replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])} f }"
+        replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])}f}"
     return replace_param
 
 

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -279,29 +279,40 @@ def _replace_param_transform_string(param):
                 exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
                 new_param = locals()['exec_param']
         else:
-            if type_mapping_match_group.group(1) == 'STR':
-                replace_param = type_mapping_match_group.group(2)
-            elif type_mapping_match_group.group(1) == 'UPPER':
-                replace_param = type_mapping_match_group.group(2).upper()
-            elif type_mapping_match_group.group(1) == 'LOWER':
-                replace_param = type_mapping_match_group.group(2).lower()
-            elif type_mapping_match_group.group(1) == 'REPLACE':
-                params_to_replace = type_mapping_match_group.group(2).split('::')
-                replace_param = params_to_replace[2] if len(params_to_replace) > 2 else ''
-                param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\n' else '\n'
-                param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\r' else '\r'
-                replace_param = params_to_replace[0].replace(param_to_replace, replace_param).replace('  ', ' ').replace('  ', ' ')
-            elif type_mapping_match_group.group(1) == 'DATE':
-                params_to_replace = type_mapping_match_group.group(2).split('::')
-                date_actual_format = '%Y/%m/%d %H:%M:%S'
-                replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format,\
-                    capitalize=False)
-            elif type_mapping_match_group.group(1) == 'TITLE':
-                replace_param = "".join(map(min, zip(type_mapping_match_group.group(2),
-                                                     type_mapping_match_group.group(2).title())))
-            new_param = new_param.replace(
-                type_mapping_match_group.group(), replace_param)
+            replace_param = _update_param_transform_string(type_mapping_match_group)
+            new_param = new_param.replace(type_mapping_match_group.group(), replace_param)
     return new_param, param_transformed
+
+
+def _update_param_transform_string(type_mapping_match_group):
+    """
+    Transform param value according to the specified prefix.
+    Available transformations: STR, UPPER, LOWER, REPLACE, DATE, TITLE
+    
+    :param type_mapping_match_group: match group
+    :return: return the string with the replaced param
+    """
+    if type_mapping_match_group.group(1) == 'STR':
+        replace_param = type_mapping_match_group.group(2)
+    elif type_mapping_match_group.group(1)  == 'UPPER':
+        replace_param = type_mapping_match_group.group(2).upper()
+    elif type_mapping_match_group.group(1)  == 'LOWER':
+        replace_param = type_mapping_match_group.group(2).lower()
+    elif type_mapping_match_group.group(1)  == 'REPLACE':
+        params_to_replace = type_mapping_match_group.group(2).split('::')
+        replace_param = params_to_replace[2] if len(params_to_replace) > 2 else ''
+        param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\n' else '\n'
+        param_to_replace = params_to_replace[1] if params_to_replace[1] != '\\r' else '\r'
+        replace_param = params_to_replace[0].replace(param_to_replace, replace_param)\
+            .replace('  ', ' ').replace('  ', ' ')
+    elif type_mapping_match_group.group(1)  == 'DATE':
+        params_to_replace = type_mapping_match_group.group(2).split('::')
+        date_actual_format = '%Y/%m/%d %H:%M:%S'
+        replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format, \
+            capitalize=False)
+    elif type_mapping_match_group.group(1)  == 'TITLE':
+        replace_param = "".join(map(min, zip(type_mapping_match_group.group(2), type_mapping_match_group.group(2).title())))
+    return replace_param
 
 
 def _replace_param_date(param, language):

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -229,12 +229,13 @@ def _get_rounded_float_number(param):
     :param param: param to format
     :return: float as string with the expected decimals
     """
-    type_mapping_regex = r'\[(ROUND):([\w\W]*)::(\d)\]'
+    type_mapping_regex = r'\[(ROUND):([\w\W]*)\]'
     type_mapping_match_group = re.match(type_mapping_regex, param)
-
-    replace_params = type_mapping_match_group.group(2).split('::')
-    replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])}f}"
-    return replace_param
+    if type_mapping_match_group and type_mapping_match_group.group(1) == 'ROUND':     
+        replace_params = type_mapping_match_group.group(2).split('::')
+        replace_param = f"{round(float(replace_params[0]), int(replace_params[1])):.{int(replace_params[1])}f}"
+        return replace_param
+    return ''
 
 
 def _get_random_phone_number():

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -309,9 +309,9 @@ def _update_param_transform_string(type_mapping_match_group):
         params_to_replace = type_mapping_match_group.group(2).split('::')
         date_actual_format = '%Y/%m/%d %H:%M:%S'
         replace_param = _format_date_spanish(params_to_replace[0], params_to_replace[1], date_actual_format, 
-                                            capitalize=False)
+                                             capitalize=False)
     elif type_mapping_match_group.group(1) == 'TITLE':
-        replace_param = "".join(map(min, zip(type_mapping_match_group.group(2), 
+        replace_param = "".join(map(min, zip(type_mapping_match_group.group(2),
                                              type_mapping_match_group.group(2).title())))
     return replace_param
 


### PR DESCRIPTION
- Allow negative indexes for list elements in context searches. Example: [CONTEXT:element.-1]
- Add support for JSON strings to the `DICT` and `LIST`` replacement. Example: [DICT:{"key": true}], [LIST:[null]]
- Add `REPLACE` replacement, to replace a substring with another. Example: [REPLACE:[CONTEXT:some_url]::https::http]
- Add `TITLE` replacement, to apply Python's title() function. Example: [TITLE:the title]
- Add `ROUND` replacement, float number to a string with the indicated number of decimals. Example: [ROUND:3.3333::2]