### PR TITLE
QAWTO: Fix  appium selenium compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests~=2.27            # api tests
-selenium~=4.0             # web tests
-Appium-Python-Client~=2.3 # mobile tests
-Pillow~=10.1              # visual testing
+requests~=2.27                      # api tests
+selenium>=4.1.0,<4.9.0              # web tests
+Appium-Python-Client>=2.2.0,<2.10.0 # mobile tests
+Pillow~=10.1                        # visual testing
 screeninfo~=0.8
 lxml~=5.1
 Faker~=25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests~=2.27                      # api tests
-selenium>=4.1.0,<4.9.0              # web tests
-Appium-Python-Client>=2.2.0,<2.10.0 # mobile tests
+selenium>=4.1.0,<4.12.0             # web tests
+Appium-Python-Client>=2.10.0,<3.0.0 # mobile tests
 Pillow~=10.1                        # visual testing
 screeninfo~=0.8
 lxml~=5.1


### PR DESCRIPTION
As we have currently defined the requirements, the Appliun Python client and Selenium version we migh have incompatibilities.
We need to follow this matrix : [compatibility](https://github.com/appium/python-client?tab=readme-ov-file#compatibility-matrix)

I've choosen the latest one for the Appium 2 version which is the most like used with the current configuration:
![image](https://github.com/user-attachments/assets/559daa06-0dc3-4fcb-b2f1-9933c461304f)
