### PR TITLE
feat: allow to save a jpg diff file in gui step

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ v3.3.1
 
 *Release date: In development*
 
+ - Allow to save the diff image in jpg format for visual tests working with jpg
+
 v3.3.0
 ------
 

--- a/toolium/visual_test.py
+++ b/toolium/visual_test.py
@@ -305,7 +305,7 @@ class VisualTest(object):
                 baseline_max.paste(baseline.convert('RGB'))
 
         # Generate and save diff image
-        diff_path = image_path.replace('.png', '.diff.png')
+        diff_path = image_path.replace('.png', '.diff.png').replace('.jpg', '.diff.jpg')
         diff_pixels_percentage = self.save_differences_image(image_max, baseline_max, diff_path)
 
         # Check differences and add to report


### PR DESCRIPTION
When working with jpg baselines, it is not rightly saved the diff file because of not replacing anything when creating the diff file name.

This way it will work for png and jpg.