### PR TITLE
Fix row parsing when there is a #

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v3.3.1
 *Release date: In development*
 
  - Allow to save the diff image in jpg format for visual tests working with jpg
+ - Fix the use of # character in tables declared in the actions before feature
 
 v3.3.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ v3.3.1
 *Release date: In development*
 
  - Allow to save the diff image in jpg format for visual tests working with jpg
- - Fix the use of # character in tables declared in the actions before feature
+ - Fix the use of the # character in the actions defined in the feature description (Actions Before/After...)
 
 v3.3.0
 ------

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -165,9 +165,9 @@ class DynamicEnvironment:
         step_text_start = False
         for row in description:
             if label_exists != EMPTY:
-                # in case of a line with a comment, it is removed
-                if "#" in row:
-                    row = row[0:row.find("#")].strip()
+                # The row is removed if it's a comment 
+                if row.strip().startswith("#"):
+                    row = ""
 
                 if any(row.startswith(x) for x in KEYWORDS):
                     self.actions[label_exists].append(row)

--- a/toolium/behave/env_utils.py
+++ b/toolium/behave/env_utils.py
@@ -165,7 +165,7 @@ class DynamicEnvironment:
         step_text_start = False
         for row in description:
             if label_exists != EMPTY:
-                # The row is removed if it's a comment 
+                # The row is removed if it's a comment
                 if row.strip().startswith("#"):
                     row = ""
 


### PR DESCRIPTION
Se ha detectado que cuando se usaba # en los valores de una tabla declarada en el actions before the feature, lo que había a continuación se eliminaba. Esta PR soluciona eso. Puede verse un ejemplo en el parametro description, todo lo que va a continuación de # era eliminado

```
  Actions Before The Feature:
     Given I create a personal purpose using the following params as client "[ENV:BAIKAL_AUTH_CLIENT]"
          | param_name   | param_value                                                          |
          | id           | qa_[CONTEXT:feature_name]_purpose_contract                           |
          | lawful_basis | contract                                                             |
          | title        | qa_[CONTEXT:feature_name]_purpose_contract                           |
          | description  | qa_[CONTEXT:feature_name]_purpose_description_this#estodeberiaentrar |
          | pi_scopes    | qa_piscope_roles_1                                                   |
```