### PR TITLE
Update dataset.py for Python 3.13 

### DIFF
--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -265,8 +265,9 @@ def _replace_param_transform_string(param):
             except json.decoder.JSONDecodeError:
                 new_param = eval(type_mapping_match_group.group(2))
         elif type_mapping_match_group.group(1) in ['INT', 'FLOAT']:
-            exec(f'exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})')
-            new_param = locals()['exec_param']
+            exec_env = {}
+            exec(f"exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})", {}, exec_env)
+            new_param = exec_env['exec_param']
         else:
             replace_param = _get_substring_replacement(type_mapping_match_group)
             new_param = new_param.replace(type_mapping_match_group.group(), replace_param)

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -266,7 +266,10 @@ def _replace_param_transform_string(param):
                 new_param = eval(type_mapping_match_group.group(2))
         elif type_mapping_match_group.group(1) in ['INT', 'FLOAT']:
             exec_env = {}
-            exec(f"exec_param = {type_mapping_match_group.group(1).lower()}({type_mapping_match_group.group(2)})", {}, exec_env)
+            type_str = type_mapping_match_group.group(1).lower()
+            value_str = type_mapping_match_group.group(2)
+            exec_code = f"exec_param = {type_str}({value_str})"
+            exec(exec_code, {}, exec_env)
             new_param = exec_env['exec_param']
         else:
             replace_param = _get_substring_replacement(type_mapping_match_group)


### PR DESCRIPTION
Fix exec/locals incompatibility with Python 3.13 by using explicit exec environment

Python 3.13 no longer guarantees that variables created via exec() are visible in locals(),
so replaced usage of locals()['exec_param'] with an explicit namespace dictionary passed to exec().
This ensures compatibility across Python versions and avoids runtime errors.