### PR TITLE
chore: Include lang modification during execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ v3.5.0
 
 - Add support for Python 3.13
 - Remove Python 3.8 support (Python 3.8 reached the end of its life on October 14th, 2024)
+- Add `LANG` replacement, to use different language translations. Example: [LANG:some_text::new_language]
 
 v3.4.0
 ------

--- a/toolium/test/utils/test_dataset_map_param.py
+++ b/toolium/test/utils/test_dataset_map_param.py
@@ -112,6 +112,17 @@ def test_a_lang_param():
     assert expected == result
 
 
+def test_a_lang_param_modified():
+    """
+    Verification of a mapped parameter as LANG
+    """
+    dataset.language_terms = {"home": {"button": {"send": {"es": "enviar", "en": "send"}}}}
+    dataset.language = "es"
+    result = map_param("[LANG:home.button.send::en]")
+    expected = "send"
+    assert expected == result
+
+
 unknown_lang_keys = [
     ('unknown'),
     ('home.unknown'),

--- a/toolium/utils/dataset.py
+++ b/toolium/utils/dataset.py
@@ -783,18 +783,24 @@ def get_message_property(param, language_terms, language_key):
     :param language_key: language key
     :return: the message mapped to the given key in the given language
     """
-    key_list = param.split(".")
+    if '::' in param:
+        lang_param, expected_lang = param.split('::')
+    else:
+        lang_param = param
+        expected_lang = language_key
+
+    key_list = lang_param.split(".")
     language_terms_aux = deepcopy(language_terms)
     try:
         for key in key_list:
             language_terms_aux = language_terms_aux[key]
-        logger.debug(f"Mapping language param '{param}' to its configured value '{language_terms_aux[language_key]}'")
+        logger.debug(f"Mapping language param '{lang_param}' to its configured value '{language_terms_aux[language_key]}'")
     except KeyError:
-        msg = f"Mapping chain '{param}' not found in the language properties file"
+        msg = f"Mapping chain '{lang_param}' not found in the language properties file"
         logger.error(msg)
         raise KeyError(msg)
 
-    return language_terms_aux[language_key]
+    return language_terms_aux[expected_lang]
 
 
 def get_translation_by_poeditor_reference(reference, poeditor_terms):


### PR DESCRIPTION
- Add `LANG` replacement, to use different language translations. Example: [LANG:some_text::new_language]