### PR TITLE
fix: key error when outline with accuracy and bug tag

### DIFF
--- a/toolium/utils/ai_utils/accuracy.py
+++ b/toolium/utils/ai_utils/accuracy.py
@@ -167,12 +167,11 @@ def patch_scenario_with_accuracy(context, scenario, data_key_suffix, accuracy=0.
                 scenario.set_status(Status.failed)
                 scenario.exception = AssertionError(final_message)
 
+            after_accuracy_scenario(context, scenario)
+
         # Clean accuracy execution data from context
         context.storage.pop('accuracy_execution_data', None)
         context.storage.pop('accuracy_execution_index', None)
-
-        after_accuracy_scenario(context, scenario)
-
         return run_response
 
     scenario_run = scenario.run


### PR DESCRIPTION
A KeyError occurs when Allure attempts to close a test that does not exist in its internal registry. 
Fix: Avoid after_scenario when a scenario is skipped

This error was found using:
```bash
 toolium behave-runner -f <runner> 
```

Error when a Scenario Outline with accuracy tag and one example has a bug or skip error.
<img width="1238" height="601" alt="runner_error" src="https://github.com/user-attachments/assets/4a1c29c0-e563-4d3d-8dfc-dfdfb9785b83" />

After solution:
<img width="747" height="126" alt="runner-fix" src="https://github.com/user-attachments/assets/adc545e2-9dec-4aef-aa3d-94229f9ed09a" />
