### PR TITLE
fix: client and api_key name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ v3.8.3
 
 *Release date: In development*
 
+- Fix `openai_request` to rename `azure_api_key` and `openai_api_key` parameters to `api_key` to avoid errors when Azure and OpenAI are created.
+- Add `openai_temperature` and `azure_temperature` parameters to be configurable in `toolium.cfg` file to set the temperature for OpenAI and Azure requests.
+- Generalize documentation for `openai_request` configuration.
+
 v3.8.2
 ------
 

--- a/docs/ai_utils.rst
+++ b/docs/ai_utils.rst
@@ -44,8 +44,10 @@ azure_api_key: your-azure-api-key
 azure_endpoint: https://your-endpoint.azure.com
 api_version: 2025-01-01-preview
 azure_deployment: gpt-4o-mini
+azure_temperature: 0.7 # Optional Temperature for OpenAI model, between 0 and 1.
 # If you are using OpenAI directly
 openai_api_key: your-openai-api-key
+openai_temperature: 0.7 # Optional Temperature for OpenAI model, between 0 and 1.
 
 Different AI providers can be used in the same project.
 

--- a/docs/ai_utils.rst
+++ b/docs/ai_utils.rst
@@ -95,6 +95,7 @@ The required parameters will vary depending on your access type (direct OpenAI o
 
 [AI]
 text_similarity_method: azure_openai
+azure_api_key: your-azure-api-key  # Or openai_api_key: your-openai-api-key if you are using OpenAI directly
 azure_endpoint: https://your-endpoint.azure.com
 api_version: 2025-01-01-preview
 azure_deployment: gpt-4o-mini
@@ -161,7 +162,7 @@ Default text analysis method can be set in the properties.cfg file with the prop
 
     [AI]
     text_analysis_method: openai  # Options: 'openai', 'azure_openai' (default: azure_openai)
-
+    azure_api_key: your-azure-api-key  # Or openai_api_key: your-openai-api-key if you are using OpenAI directly
 
 Response Format
 ~~~~~~~~~~~~~~~
@@ -384,6 +385,7 @@ Default OpenAI model can be set in the properties.cfg file in the *[AI]* section
     [AI]
     provider: azure  # AI provider to use, openai by default
     openai_model: gpt-4o  # OpenAI model to use, gpt-4o-mini by default
+    azure_api_key: your-azure-api-key  # Or openai_api_key: your-openai-api-key if you are using OpenAI directly
 
 Installation
 ~~~~~~~~~~~~

--- a/docs/ai_utils.rst
+++ b/docs/ai_utils.rst
@@ -3,6 +3,52 @@
 AI Utils
 ========
 
+Installation and configuration
+------------------------------
+
+Make sure to install the required libraries for the chosen method. For SpaCy, Sentence Transformers or OpenAI LLM, you
+can install them with the following command:
+
+.. code-block:: bash
+
+    pip install toolium[ai]
+
+**Additional Requirements:**
+
+For SpaCy, you also need to download the language model, i.e. for small English model:
+
+.. code-block:: bash
+
+    python -m spacy download en_core_web_sm
+
+For OpenAI LLM, you need to set up your configuration using environment variables or include it in the Toolium configuration.
+The required parameters will vary depending on your access type (direct OpenAI or Azure OpenAI):
+
+.. code-block:: bash
+
+    # For example, to configure direct OpenAI access:
+    OPENAI_API_KEY=<your_api_key>
+
+.. code-block:: bash
+
+    # For example, to configure Azure OpenAI:
+    AZURE_OPENAI_API_KEY=<your_api_key>
+    AZURE_OPENAI_ENDPOINT=<your_endpoint>
+    OPENAI_API_VERSION=<your_api_version>
+
+*[AI]* section::
+
+[AI]
+# If you are using Azure OpenAI
+azure_api_key: your-azure-api-key
+azure_endpoint: https://your-endpoint.azure.com
+api_version: 2025-01-01-preview
+azure_deployment: gpt-4o-mini
+# If you are using OpenAI directly
+openai_api_key: your-openai-api-key
+
+Different AI providers can be used in the same project.
+
 Text Similarity
 ---------------
 
@@ -57,49 +103,6 @@ To select models for each method, you can refer to the following links:
 * `SpaCy models <https://spacy.io/models>`_
 * `Sentence Transformers models <https://github.com/UKPLab/sentence-transformers>`_
 * `OpenAI models <https://platform.openai.com/docs/models>`_
-
-Installation
-~~~~~~~~~~~~
-
-Make sure to install the required libraries for the chosen method. For SpaCy, Sentence Transformers or OpenAI LLM, you
-can install them with the following command:
-
-.. code-block:: bash
-
-    pip install toolium[ai]
-
-**Additional Requirements:**
-
-For SpaCy, you also need to download the language model, i.e. for small English model:
-
-.. code-block:: bash
-
-    python -m spacy download en_core_web_sm
-
-For OpenAI LLM, you need to set up your configuration using environment variables or include it in the Toolium configuration.
-The required parameters will vary depending on your access type (direct OpenAI or Azure OpenAI):
-
-.. code-block:: bash
-
-    # For example, to configure direct OpenAI access:
-    OPENAI_API_KEY=<your_api_key>
-
-.. code-block:: bash
-
-    # For example, to configure Azure OpenAI:
-    AZURE_OPENAI_API_KEY=<your_api_key>
-    AZURE_OPENAI_ENDPOINT=<your_endpoint>
-    OPENAI_API_VERSION=<your_api_version>
-
-*[AI]* section::
-
-[AI]
-text_similarity_method: azure_openai
-azure_api_key: your-azure-api-key  # Or openai_api_key: your-openai-api-key if you are using OpenAI directly
-azure_endpoint: https://your-endpoint.azure.com
-api_version: 2025-01-01-preview
-azure_deployment: gpt-4o-mini
-
 
 Text Criteria Analysis
 ----------------------
@@ -162,7 +165,6 @@ Default text analysis method can be set in the properties.cfg file with the prop
 
     [AI]
     text_analysis_method: openai  # Options: 'openai', 'azure_openai' (default: azure_openai)
-    azure_api_key: your-azure-api-key  # Or openai_api_key: your-openai-api-key if you are using OpenAI directly
 
 Response Format
 ~~~~~~~~~~~~~~~
@@ -236,13 +238,6 @@ Default readability method and spacy model can be set in the *[AI]* section of t
 For more information on SpaCy models, you can refer to the following link:
 
 * `SpaCy models <https://spacy.io/models>`_
-
-Installation
-~~~~~~~~~~~~
-
-The requirements are the same explained for `SpaCy` in the
-`installation section of Text Similarity <https://toolium.readthedocs.io/en/latest/ai_utils.html#installation>`_
-
 
 Answer Evaluation using LLM-as-a-Judge
 --------------------------------------
@@ -384,32 +379,6 @@ Default OpenAI model can be set in the properties.cfg file in the *[AI]* section
 
     [AI]
     provider: azure  # AI provider to use, openai by default
-    openai_model: gpt-4o  # OpenAI model to use, gpt-4o-mini by default
-    azure_api_key: your-azure-api-key  # Or openai_api_key: your-openai-api-key if you are using OpenAI directly
-
-Installation
-~~~~~~~~~~~~
-
-Make sure to install the required libraries:
-
-.. code-block:: bash
-
-    pip install toolium[ai]
-
-For Azure OpenAI, you need to set up your configuration in environment variables:
-
-.. code-block:: bash
-
-    AZURE_OPENAI_API_KEY=<your_api_key>
-    AZURE_OPENAI_ENDPOINT=<your_endpoint>
-    OPENAI_API_VERSION=<your_api_version>
-
-For standard OpenAI:
-
-.. code-block:: bash
-
-    OPENAI_API_KEY=<your_api_key>
-
 
 .. _accuracy_tags_for_behave_scenarios:
 

--- a/toolium/utils/ai_utils/openai.py
+++ b/toolium/utils/ai_utils/openai.py
@@ -55,14 +55,13 @@ def openai_request(system_message, user_message, model_name=None, azure=False, *
             if value:
                 kwargs_key = 'api_key' if key == 'azure_api_key' else key
                 kwargs.setdefault(kwargs_key, value)
+        temperature = config.get_optional('AI', 'azure_temperature', None)
     else:
-        for key in ('openai_api_key', 'openai_temperature'):
-            value = config.get_optional('AI', key)
-            if value:
-                kwargs_key = 'api_key' if key == 'openai_api_key' else key
-                kwargs.setdefault(kwargs_key, value)
+        kwargs.setdefault('api_key', config.get_optional('AI', 'openai_api_key'))
+        temperature = config.get_optional('AI', 'openai_temperature', None)
     client = AzureOpenAI(**kwargs) if azure else OpenAI(**kwargs)
     messages = []
+    temperature = float(temperature) if temperature is not None else None
     if isinstance(system_message, list):
         for prompt in system_message:
             messages.append({'role': 'system', 'content': prompt})
@@ -72,11 +71,11 @@ def openai_request(system_message, user_message, model_name=None, azure=False, *
 
     if response_format:
         completion = client.beta.chat.completions.parse(
-            model=model_name, messages=messages, response_format=response_format
+            model=model_name, messages=messages, response_format=response_format, temperature=temperature
         )
         response = completion.choices[0].message.parsed
     else:
-        completion = client.chat.completions.create(model=model_name, messages=messages)
+        completion = client.chat.completions.create(model=model_name, messages=messages, temperature=temperature)
         response = completion.choices[0].message.content
     token_usage = {}
     if completion.usage:

--- a/toolium/utils/ai_utils/openai.py
+++ b/toolium/utils/ai_utils/openai.py
@@ -45,22 +45,23 @@ def openai_request(system_message, user_message, model_name=None, azure=False, *
     config = DriverWrappersPool.get_default_wrapper().config
     model_name = model_name or config.get_optional('AI', 'openai_model', 'gpt-4o-mini')
     logger.info('Calling to OpenAI API with model %s', model_name)
-
     response_format = None
     if kwargs.get('response_format'):
         response_format = kwargs.pop('response_format')
         kwargs.pop('response_format', None)
-    client = AzureOpenAI(**kwargs) if azure else OpenAI(**kwargs)
     if azure:
         for key in ('azure_api_key', 'azure_endpoint', 'api_version', 'azure_deployment'):
             value = config.get_optional('AI', key)
             if value:
-                kwargs.setdefault(key, value)
+                kwargs_key = 'api_key' if key == 'azure_api_key' else key
+                kwargs.setdefault(kwargs_key, value)
     else:
         for key in ('openai_api_key', 'openai_temperature'):
             value = config.get_optional('AI', key)
             if value:
-                kwargs.setdefault(key, value)
+                kwargs_key = 'api_key' if key == 'openai_api_key' else key
+                kwargs.setdefault(kwargs_key, value)
+    client = AzureOpenAI(**kwargs) if azure else OpenAI(**kwargs)
     messages = []
     if isinstance(system_message, list):
         for prompt in system_message:


### PR DESCRIPTION
Fix bug:
- Azure or Openai client have to be built after kwargs update.
- azure_api_key-openai_api_key name should be update to 'api_key'.